### PR TITLE
Add emoji field to labels (Vibe Kanban)

### DIFF
--- a/server/models/labels.model.ts
+++ b/server/models/labels.model.ts
@@ -13,9 +13,20 @@ export default function (app: Application): Knex {
           table.string('color');
           table.string('color_active');
           table.integer('user_id');
+          table.string('emoji').nullable();
         })
         .then(() => console.log(`Created ${tableName} table`))
         .catch((e) => console.error(`Error creating ${tableName} table`, e));
+    } else {
+      db.schema.hasColumn(tableName, 'emoji').then((hasEmoji) => {
+        if (!hasEmoji) {
+          db.schema
+            .table(tableName, (table) => {
+              table.string('emoji').nullable();
+            })
+            .catch((e) => console.error(`Error adding emoji column to ${tableName} table`, e));
+        }
+      });
     }
   });
   return db;

--- a/src/Days/Settings/LabelsSettings/index.tsx
+++ b/src/Days/Settings/LabelsSettings/index.tsx
@@ -35,6 +35,7 @@ const LabelsSettings = () => {
   >([]);
   const [isNewLabelActive, setIsNewLabelActive] = React.useState(false);
   const [labelToEdit, setLabelToEdit] = React.useState<number | null>(null);
+  const [newLabelEmoji, setNewLabelEmoji] = React.useState('');
   const [isEdit, setIsEdit] = React.useState(false);
   const labelsData = useQuery(['labels'], getLabels);
 
@@ -44,6 +45,7 @@ const LabelsSettings = () => {
         name: newLabelName,
         color: newLabelColor[0],
         color_active: newLabelColor[1],
+        emoji: newLabelEmoji || null,
       }),
     ['labels'],
     labelToEdit,
@@ -51,11 +53,13 @@ const LabelsSettings = () => {
       name: newLabelName,
       color: newLabelColor[0],
       color_active: newLabelColor[1],
+      emoji: newLabelEmoji || null,
     }),
     () => {
       setIsEdit(false);
       setNewLabelName('');
       setNewLabelColor([]);
+      setNewLabelEmoji('');
       setIsNewLabelActive(false);
     },
   );
@@ -65,6 +69,7 @@ const LabelsSettings = () => {
         name: newLabelName,
         color: newLabelColor[0],
         color_active: newLabelColor[1],
+        emoji: newLabelEmoji || null,
       }),
     ['labels'],
     (old: LabelType[]) => [
@@ -74,6 +79,7 @@ const LabelsSettings = () => {
         name: newLabelName,
         color: newLabelColor[0],
         color_active: newLabelColor[1],
+        emoji: newLabelEmoji || null,
       },
     ],
   );
@@ -120,6 +126,7 @@ const LabelsSettings = () => {
     setIsEdit(false);
     setNewLabelName('');
     setNewLabelColor([]);
+    setNewLabelEmoji('');
     setIsNewLabelActive(false);
   };
 
@@ -131,6 +138,7 @@ const LabelsSettings = () => {
     setIsAdd(false);
     setNewLabelName(editLabel.name);
     setNewLabelColor([editLabel.color, editLabel.color_active]);
+    setNewLabelEmoji(editLabel.emoji || '');
   };
 
   const handleAddClicked = () => {
@@ -139,6 +147,7 @@ const LabelsSettings = () => {
     setLabelToEdit(null);
     setNewLabelName('');
     setNewLabelColor([]);
+    setNewLabelEmoji('');
     setIsNewLabelActive(false);
   };
 
@@ -193,6 +202,16 @@ const LabelsSettings = () => {
                   value={newLabelName}
                   onChange={(e) => setNewLabelName(e.target.value)}
                   label="Name"
+                />
+              </Grid>
+              <Grid item>
+                <TextField
+                  name="labelEmoji"
+                  variant="standard"
+                  value={newLabelEmoji}
+                  onChange={(e) => setNewLabelEmoji(e.target.value)}
+                  label="Emoji"
+                  inputProps={{ maxLength: 2 }}
                 />
               </Grid>
               <Grid item>

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -28,6 +28,7 @@ export type LabelType = {
   name?: string;
   color?: string;
   color_active?: string;
+  emoji?: string | null;
 };
 
 export type CommentType = {


### PR DESCRIPTION
## What changed

- Added a nullable `emoji` column (string) to the `labels` database table
- Updated `LabelType` TypeScript type to include `emoji?: string | null`
- Added an **Emoji** text field (max 2 characters) to the label create/edit form in Settings

## Why

Labels previously only supported a name and color pair. Adding an emoji field allows users to associate a visual emoji character with each label, making them easier to identify at a glance.

## Implementation details

- **DB model** (`server/models/labels.model.ts`): `emoji` is added to `createTable`. For existing databases where the table already exists, a `hasColumn` check runs on startup and performs an `ALTER TABLE` to add the column if missing — no migration system required.
- **Shared type** (`src/shared/types/index.ts`): `LabelType` extended with `emoji?: string | null`.
- **Form** (`src/Days/Settings/LabelsSettings/index.tsx`): New `newLabelEmoji` state drives a TextField rendered between Name and Color. The value is included in both `postLabel` and `putLabel` API calls, pre-filled when opening the edit form, and reset on cancel/submit.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)