### PR TITLE
Add date-based context segments to diary posts and history (Vibe Kanban)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,15 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  globals: {
-    'ts-jest': {
-      diagnostics: false
-    }
-  }
+  roots: ['<rootDir>/test'],
+  testMatch: ['**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        diagnostics: false,
+        tsconfig: 'server/tsconfig.json',
+      },
+    ],
+  },
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "test-server": "npm run lint && npm run compile && npm run jest",
     "lint": "eslint server/. test/. src/.",
+    "compile": "npm run build-server",
     "dev": "concurrently \"npm run dev-server\" \"npm run dev-client\"",
     "dev-server": "ts-node-dev --no-notify -P server/tsconfig.json server/",
     "start-server": "npm run compile && node lib/",

--- a/server/models/context-segments.model.ts
+++ b/server/models/context-segments.model.ts
@@ -1,0 +1,27 @@
+import { Knex } from 'knex';
+import { Application } from '../declarations';
+
+export default function (app: Application): Knex {
+  const db: Knex = app.get('knexClient');
+  const tableName = 'context_segments';
+  db.schema.hasTable(tableName).then((exists) => {
+    if (!exists) {
+      db.schema
+        .createTable(tableName, (table) => {
+          table.increments('id');
+          table.string('title');
+          table.text('details');
+          table.date('start_date');
+          table.date('end_date').nullable();
+          table.integer('user_id');
+          table.datetime('created_at').defaultTo(db.fn.now());
+          table.datetime('updated_at').defaultTo(db.fn.now());
+          table.index(['user_id', 'start_date']);
+          table.index(['user_id', 'end_date']);
+        })
+        .then(() => console.log(`Created ${tableName} table`))
+        .catch((e) => console.error(`Error creating ${tableName} table`, e));
+    }
+  });
+  return db;
+}

--- a/server/models/labels.model.ts
+++ b/server/models/labels.model.ts
@@ -24,7 +24,12 @@ export default function (app: Application): Knex {
             .table(tableName, (table) => {
               table.string('emoji').nullable();
             })
-            .catch((e) => console.error(`Error adding emoji column to ${tableName} table`, e));
+            .catch((e) =>
+              console.error(
+                `Error adding emoji column to ${tableName} table`,
+                e,
+              ),
+            );
         }
       });
     }

--- a/server/models/users.model.ts
+++ b/server/models/users.model.ts
@@ -33,7 +33,9 @@ export default function (app: Application): Knex {
             .table(tableName, (table) => {
               table.text('apps');
             })
-            .catch((e) => console.error(`Error adding apps column to ${tableName}`, e));
+            .catch((e) =>
+              console.error(`Error adding apps column to ${tableName}`, e),
+            );
         }
       });
     }

--- a/server/services/blog-post-block/blog-post-block.hooks.ts
+++ b/server/services/blog-post-block/blog-post-block.hooks.ts
@@ -1,4 +1,3 @@
-import { HooksObject } from '@feathersjs/feathers';
 import * as authentication from '@feathersjs/authentication';
 // Don't remove this comment. It's needed to format import lines nicely.
 

--- a/server/services/blog-post/blog-post.hooks.ts
+++ b/server/services/blog-post/blog-post.hooks.ts
@@ -1,4 +1,3 @@
-import { HooksObject } from '@feathersjs/feathers';
 import * as authentication from '@feathersjs/authentication';
 // Don't remove this comment. It's needed to format import lines nicely.
 

--- a/server/services/comments/comments.hooks.ts
+++ b/server/services/comments/comments.hooks.ts
@@ -1,4 +1,3 @@
-import { HooksObject } from '@feathersjs/feathers';
 import * as authentication from '@feathersjs/authentication';
 import { removeUserId } from '../../app.hooks';
 // Don't remove this comment. It's needed to format import lines nicely.

--- a/server/services/context-segments/context-segments.class.ts
+++ b/server/services/context-segments/context-segments.class.ts
@@ -1,0 +1,109 @@
+import { BadRequest, NotFound } from '@feathersjs/errors';
+import { Params } from '@feathersjs/feathers';
+import dayjs from 'dayjs';
+import { KnexServiceOptions, Service } from 'feathers-knex';
+import { Application } from '../../declarations';
+
+type ContextSegmentData = {
+  mode?: 'split';
+  splitDate?: string;
+  newTitle?: string;
+  newDetails?: string;
+  title?: string;
+  details?: string;
+  start_date?: string;
+  end_date?: string | null;
+};
+
+export class ContextSegments extends Service {
+  app: Application;
+  //eslint-disable-next-line @typescript-eslint/no-unused-vars
+  constructor(options: Partial<KnexServiceOptions>, app: Application) {
+    super({
+      ...options,
+      name: 'context_segments',
+    });
+    this.app = app;
+  }
+
+  async find(params: Params) {
+    const date = params.query?.date;
+    const isActiveQuery = params.query?.active;
+
+    if (date && isActiveQuery) {
+      const knex = this.app.get('knexClient');
+      return knex('context_segments')
+        .where({ user_id: params.user?.id })
+        .where('start_date', '<=', date)
+        .where((qb) => {
+          qb.whereNull('end_date').orWhere('end_date', '>=', date);
+        })
+        .orderBy('start_date', 'desc');
+    }
+
+    return super.find(params);
+  }
+
+  async patch(id: string | number, data: ContextSegmentData, params: Params) {
+    if (data?.mode !== 'split') {
+      return super.patch(id, data, params);
+    }
+
+    if (!id) {
+      throw new BadRequest('Segment id is required for split.');
+    }
+
+    if (!data.splitDate) {
+      throw new BadRequest('splitDate is required.');
+    }
+
+    const oldSegment = await super.get(id, params);
+    if (!oldSegment) {
+      throw new NotFound('Context segment not found.');
+    }
+
+    const splitDate = dayjs(data.splitDate).format('YYYY-MM-DD');
+    const oldStartDate = dayjs(oldSegment.start_date).format('YYYY-MM-DD');
+    const oldEndDate = oldSegment.end_date
+      ? dayjs(oldSegment.end_date).format('YYYY-MM-DD')
+      : null;
+
+    if (splitDate < oldStartDate || (oldEndDate && splitDate > oldEndDate)) {
+      throw new BadRequest('splitDate must be within the segment date range.');
+    }
+
+    if (splitDate === oldStartDate) {
+      return super.patch(
+        id,
+        {
+          title: data.newTitle ?? oldSegment.title,
+          details: data.newDetails ?? oldSegment.details,
+        },
+        params,
+      );
+    }
+
+    const previousEndDate = dayjs(splitDate)
+      .subtract(1, 'day')
+      .format('YYYY-MM-DD');
+
+    await super.patch(
+      id,
+      {
+        end_date: previousEndDate,
+      },
+      params,
+    );
+
+    return super.create(
+      {
+        user_id: oldSegment.user_id,
+        title: data.newTitle ?? oldSegment.title,
+        details: data.newDetails ?? oldSegment.details,
+        start_date: splitDate,
+        end_date: oldEndDate,
+      },
+      params,
+    );
+  }
+}

--- a/server/services/context-segments/context-segments.class.ts
+++ b/server/services/context-segments/context-segments.class.ts
@@ -2,6 +2,7 @@ import { BadRequest, NotFound } from '@feathersjs/errors';
 import { Params } from '@feathersjs/feathers';
 import dayjs from 'dayjs';
 import { KnexServiceOptions, Service } from 'feathers-knex';
+import { Knex } from 'knex';
 import { Application } from '../../declarations';
 
 type ContextSegmentData = {
@@ -35,7 +36,7 @@ export class ContextSegments extends Service {
       return knex('context_segments')
         .where({ user_id: params.user?.id })
         .where('start_date', '<=', date)
-        .where((qb) => {
+        .where((qb: Knex.QueryBuilder) => {
           qb.whereNull('end_date').orWhere('end_date', '>=', date);
         })
         .orderBy('start_date', 'desc');

--- a/server/services/context-segments/context-segments.hooks.ts
+++ b/server/services/context-segments/context-segments.hooks.ts
@@ -1,0 +1,50 @@
+import { HooksObject } from '@feathersjs/feathers';
+import * as authentication from '@feathersjs/authentication';
+import { filterByUser } from '../../app.hooks';
+
+const { authenticate } = authentication.hooks;
+
+const withTimestamp = (context: any) => {
+  const now = new Date()
+    .toISOString()
+    .slice(0, 19)
+    .replace('T', ' ');
+  context.data = {
+    ...context.data,
+    updated_at: now,
+    ...(context.method === 'create' ? { created_at: now } : {}),
+  };
+  return context;
+};
+
+export default {
+  before: {
+    all: [authenticate('jwt')],
+    find: [filterByUser],
+    get: [],
+    create: [withTimestamp],
+    update: [withTimestamp],
+    patch: [withTimestamp],
+    remove: [],
+  },
+
+  after: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: [],
+  },
+
+  error: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: [],
+  },
+} as HooksObject;

--- a/server/services/context-segments/context-segments.hooks.ts
+++ b/server/services/context-segments/context-segments.hooks.ts
@@ -5,10 +5,7 @@ import { filterByUser } from '../../app.hooks';
 const { authenticate } = authentication.hooks;
 
 const withTimestamp = (context: any) => {
-  const now = new Date()
-    .toISOString()
-    .slice(0, 19)
-    .replace('T', ' ');
+  const now = new Date().toISOString().slice(0, 19).replace('T', ' ');
   context.data = {
     ...context.data,
     updated_at: now,

--- a/server/services/context-segments/context-segments.service.ts
+++ b/server/services/context-segments/context-segments.service.ts
@@ -1,0 +1,25 @@
+// Initializes the `context-segments` service on path `/context-segments`
+import { ServiceAddons } from '@feathersjs/feathers';
+import { Application } from '../../declarations';
+import createModel from '../../models/context-segments.model';
+import { ContextSegments } from './context-segments.class';
+import hooks from './context-segments.hooks';
+
+declare module '../../declarations' {
+  interface ServiceTypes {
+    'context-segments': ContextSegments & ServiceAddons<any>;
+  }
+}
+
+export default function (app: Application): void {
+  const options = {
+    Model: createModel(app),
+    paginate: app.get('paginate'),
+    userAware: true,
+  };
+
+  app.use('/context-segments', new ContextSegments(options, app));
+
+  const service = app.service('context-segments');
+  service.hooks(hooks);
+}

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -16,6 +16,7 @@ import comments from './comments/comments.service';
 import countdown from './countdown/countdown.service';
 import blogPost from './blog-post/blog-post.service';
 import blogPostBlock from './blog-post-block/blog-post-block.service';
+import contextSegments from './context-segments/context-segments.service';
 import watch from './watch/watch.service';
 // Don't remove this comment. It's needed to format import lines nicely.
 
@@ -37,5 +38,6 @@ export default function (app: Application): void {
   app.configure(countdown);
   app.configure(blogPost);
   app.configure(blogPostBlock);
+  app.configure(contextSegments);
   app.configure(watch);
 }

--- a/server/services/labels/labels.hooks.ts
+++ b/server/services/labels/labels.hooks.ts
@@ -1,4 +1,3 @@
-import { HooksObject } from '@feathersjs/feathers';
 import * as authentication from '@feathersjs/authentication';
 import { filterByUser } from '../../app.hooks';
 // Don't remove this comment. It's needed to format import lines nicely.

--- a/server/services/note-category/note-category.hooks.ts
+++ b/server/services/note-category/note-category.hooks.ts
@@ -1,4 +1,3 @@
-import { HooksObject } from '@feathersjs/feathers';
 import * as authentication from '@feathersjs/authentication';
 import { filterByUser } from '../../app.hooks';
 // Don't remove this comment. It's needed to format import lines nicely.

--- a/server/services/note/note.hooks.ts
+++ b/server/services/note/note.hooks.ts
@@ -1,4 +1,3 @@
-import { HooksObject } from '@feathersjs/feathers';
 import * as authentication from '@feathersjs/authentication';
 import { filterByUser } from '../../app.hooks';
 // Don't remove this comment. It's needed to format import lines nicely.
@@ -8,10 +7,7 @@ const { authenticate } = authentication.hooks;
 const updateTimestamp = (context: any) => {
   // Format date for MySQL: YYYY-MM-DD HH:MM:SS
   const now = new Date();
-  const mysqlDateTime = now
-    .toISOString()
-    .slice(0, 19)
-    .replace('T', ' ');
+  const mysqlDateTime = now.toISOString().slice(0, 19).replace('T', ' ');
 
   context.data = {
     ...context.data,

--- a/server/services/post-labels/post-labels.hooks.ts
+++ b/server/services/post-labels/post-labels.hooks.ts
@@ -1,4 +1,3 @@
-import { HookContext, HooksObject } from '@feathersjs/feathers';
 import * as authentication from '@feathersjs/authentication';
 import { removeUserId } from '../../app.hooks';
 // Don't remove this comment. It's needed to format import lines nicely.

--- a/server/services/posts/posts-history.class.ts
+++ b/server/services/posts/posts-history.class.ts
@@ -3,6 +3,16 @@ import { Params } from '@feathersjs/feathers';
 import { Knex } from 'knex';
 import { Application } from '../../declarations';
 
+const toDateOnly = (date: unknown): string => {
+  if (typeof date === 'string') {
+    return date.slice(0, 10);
+  }
+  if (date instanceof Date) {
+    return date.toISOString().slice(0, 10);
+  }
+  return String(date).slice(0, 10);
+};
+
 export class PostsHistory extends Service {
   app: Application;
   //eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -65,6 +75,7 @@ export class PostsHistory extends Service {
       .orderBy('date', 'desc');
     const populated = await Promise.all(
       posts.map(async (post: any) => {
+        const postDate = toDateOnly(post.date);
         const [comments, labels, periods, contextSegments] = await Promise.all([
           knex('comments').where({ post_id: post.id }).orderBy('date'),
           knex('labels')
@@ -79,13 +90,9 @@ export class PostsHistory extends Service {
           ),
           knex('context_segments')
             .where({ user_id: params.user?.id })
-            .where('start_date', '<=', post.date.slice(0, 10))
+            .where('start_date', '<=', postDate)
             .where((qb: Knex.QueryBuilder) => {
-              qb.whereNull('end_date').orWhere(
-                'end_date',
-                '>=',
-                post.date.slice(0, 10),
-              );
+              qb.whereNull('end_date').orWhere('end_date', '>=', postDate);
             })
             .orderBy('start_date', 'desc'),
         ]);

--- a/server/services/posts/posts-history.class.ts
+++ b/server/services/posts/posts-history.class.ts
@@ -1,5 +1,6 @@
 import { Service, KnexServiceOptions } from 'feathers-knex';
 import { Params } from '@feathersjs/feathers';
+import { Knex } from 'knex';
 import { Application } from '../../declarations';
 
 export class PostsHistory extends Service {
@@ -79,7 +80,7 @@ export class PostsHistory extends Service {
           knex('context_segments')
             .where({ user_id: params.user?.id })
             .where('start_date', '<=', post.date.slice(0, 10))
-            .where((qb) => {
+            .where((qb: Knex.QueryBuilder) => {
               qb.whereNull('end_date').orWhere(
                 'end_date',
                 '>=',

--- a/server/services/posts/posts-history.class.ts
+++ b/server/services/posts/posts-history.class.ts
@@ -1,9 +1,14 @@
 import { Service, KnexServiceOptions } from 'feathers-knex';
 import { Params } from '@feathersjs/feathers';
+import dayjs from 'dayjs';
 import { Knex } from 'knex';
 import { Application } from '../../declarations';
 
 const toDateOnly = (date: unknown): string => {
+  const normalized = dayjs(date as any);
+  if (normalized.isValid()) {
+    return normalized.format('YYYY-MM-DD');
+  }
   if (typeof date === 'string') {
     return date.slice(0, 10);
   }

--- a/server/services/posts/posts-history.class.ts
+++ b/server/services/posts/posts-history.class.ts
@@ -64,7 +64,7 @@ export class PostsHistory extends Service {
       .orderBy('date', 'desc');
     const populated = await Promise.all(
       posts.map(async (post: any) => {
-        const [comments, labels, periods] = await Promise.all([
+        const [comments, labels, periods, contextSegments] = await Promise.all([
           knex('comments').where({ post_id: post.id }).orderBy('date'),
           knex('labels')
             .pluck('labels.id')
@@ -76,8 +76,25 @@ export class PostsHistory extends Service {
               [post.id, params.user?.id],
             ),
           ),
+          knex('context_segments')
+            .where({ user_id: params.user?.id })
+            .where('start_date', '<=', post.date.slice(0, 10))
+            .where((qb) => {
+              qb.whereNull('end_date').orWhere(
+                'end_date',
+                '>=',
+                post.date.slice(0, 10),
+              );
+            })
+            .orderBy('start_date', 'desc'),
         ]);
-        return { ...post, comments, labels, periods };
+        return {
+          ...post,
+          comments,
+          labels,
+          periods,
+          context_segments: contextSegments,
+        };
       }),
     );
     return populated;

--- a/server/services/posts/posts.class.ts
+++ b/server/services/posts/posts.class.ts
@@ -1,9 +1,14 @@
 import { Service, KnexServiceOptions } from 'feathers-knex';
 import { Paginated, Params } from '@feathersjs/feathers';
+import dayjs from 'dayjs';
 import { Knex } from 'knex';
 import { Application } from '../../declarations';
 
 const toDateOnly = (date: unknown): string => {
+  const normalized = dayjs(date as any);
+  if (normalized.isValid()) {
+    return normalized.format('YYYY-MM-DD');
+  }
   if (typeof date === 'string') {
     return date.slice(0, 10);
   }

--- a/server/services/posts/posts.class.ts
+++ b/server/services/posts/posts.class.ts
@@ -3,6 +3,16 @@ import { Paginated, Params } from '@feathersjs/feathers';
 import { Knex } from 'knex';
 import { Application } from '../../declarations';
 
+const toDateOnly = (date: unknown): string => {
+  if (typeof date === 'string') {
+    return date.slice(0, 10);
+  }
+  if (date instanceof Date) {
+    return date.toISOString().slice(0, 10);
+  }
+  return String(date).slice(0, 10);
+};
+
 export class Posts extends Service {
   app: Application;
   //eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -18,6 +28,7 @@ export class Posts extends Service {
     const posts = (await super.find(params)) as Paginated<any>;
     const populated = await Promise.all(
       posts.data.map(async (post) => {
+        const postDate = toDateOnly(post.date);
         const [comments, labels, periods, contextSegments] = await Promise.all([
           this.app
             .get('knexClient')('comments')
@@ -44,13 +55,9 @@ export class Posts extends Service {
             .where({
               user_id: params.query?.user_id,
             })
-            .where('start_date', '<=', post.date.slice(0, 10))
+            .where('start_date', '<=', postDate)
             .where((qb: Knex.QueryBuilder) => {
-              qb.whereNull('end_date').orWhere(
-                'end_date',
-                '>=',
-                post.date.slice(0, 10),
-              );
+              qb.whereNull('end_date').orWhere('end_date', '>=', postDate);
             })
             .orderBy('start_date', 'desc'),
         ]);

--- a/server/services/posts/posts.class.ts
+++ b/server/services/posts/posts.class.ts
@@ -17,7 +17,7 @@ export class Posts extends Service {
     const posts = (await super.find(params)) as Paginated<any>;
     const populated = await Promise.all(
       posts.data.map(async (post) => {
-        const [comments, labels, periods] = await Promise.all([
+        const [comments, labels, periods, contextSegments] = await Promise.all([
           this.app
             .get('knexClient')('comments')
             .where({ post_id: post.id })
@@ -38,8 +38,28 @@ export class Posts extends Service {
                   [post.id, params.query?.user_id],
                 ),
             ),
+          this.app
+            .get('knexClient')('context_segments')
+            .where({
+              user_id: params.query?.user_id,
+            })
+            .where('start_date', '<=', post.date.slice(0, 10))
+            .where((qb) => {
+              qb.whereNull('end_date').orWhere(
+                'end_date',
+                '>=',
+                post.date.slice(0, 10),
+              );
+            })
+            .orderBy('start_date', 'desc'),
         ]);
-        return { ...post, comments, labels, periods };
+        return {
+          ...post,
+          comments,
+          labels,
+          periods,
+          context_segments: contextSegments,
+        };
       }),
     );
     return {

--- a/server/services/posts/posts.class.ts
+++ b/server/services/posts/posts.class.ts
@@ -1,5 +1,6 @@
 import { Service, KnexServiceOptions } from 'feathers-knex';
 import { Paginated, Params } from '@feathersjs/feathers';
+import { Knex } from 'knex';
 import { Application } from '../../declarations';
 
 export class Posts extends Service {
@@ -44,7 +45,7 @@ export class Posts extends Service {
               user_id: params.query?.user_id,
             })
             .where('start_date', '<=', post.date.slice(0, 10))
-            .where((qb) => {
+            .where((qb: Knex.QueryBuilder) => {
               qb.whereNull('end_date').orWhere(
                 'end_date',
                 '>=',

--- a/server/services/posts/posts.hooks.ts
+++ b/server/services/posts/posts.hooks.ts
@@ -1,4 +1,3 @@
-import { HooksObject } from '@feathersjs/feathers';
 import * as authentication from '@feathersjs/authentication';
 import { filterByUser } from '../../app.hooks';
 // Don't remove this comment. It's needed to format import lines nicely.

--- a/server/services/watch/watch.hooks.ts
+++ b/server/services/watch/watch.hooks.ts
@@ -1,4 +1,3 @@
-import { HooksObject } from '@feathersjs/feathers';
 import * as authentication from '@feathersjs/authentication';
 import { filterByUser } from '../../app.hooks';
 // Don't remove this comment. It's needed to format import lines nicely.

--- a/src/Auth/Registration/index.tsx
+++ b/src/Auth/Registration/index.tsx
@@ -15,7 +15,7 @@ import VisibleIcon from '@mui/icons-material/VisibilityOutlined';
 import NotVisibleIcon from '@mui/icons-material/VisibilityOffOutlined';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
 import { useNavigate } from 'react-router';
-import { sendRegistration } from '../../shared/api/routes';
+import { sendLogin, sendRegistration } from '../../shared/api/routes';
 import { setItemToStorage, TOKEN_KEY } from '../../shared/utils/storage';
 import UIContext from '../../shared/context/UIContext';
 
@@ -40,8 +40,14 @@ const RegistrationPage = () => {
         password: form.password,
         theme: '{mode:"dark"}',
       })
+        .then(() => {
+          return sendLogin({
+            email: form.email,
+            password: form.password,
+          });
+        })
         .then((resp) => {
-          setItemToStorage(TOKEN_KEY, resp.data.Token);
+          setItemToStorage(TOKEN_KEY, resp.data.accessToken);
           navigate('/days');
         })
         .catch((err) => {

--- a/src/Days/PostList/PostCreate/ContextSegmentsPanel.tsx
+++ b/src/Days/PostList/PostCreate/ContextSegmentsPanel.tsx
@@ -23,6 +23,16 @@ type Props = {
   date: string;
 };
 
+const normalizeSegments = (val: any): ContextSegmentType[] => {
+  if (Array.isArray(val)) {
+    return val;
+  }
+  if (Array.isArray(val?.data)) {
+    return val.data;
+  }
+  return [];
+};
+
 const ContextSegmentsPanel = ({ date }: Props) => {
   const queryClient = useQueryClient();
   const queryKey = ['context_segments', date];
@@ -98,7 +108,7 @@ const ContextSegmentsPanel = ({ date }: Props) => {
     splitMutation.isLoading ||
     deleteMutation.isLoading;
 
-  const segments = (data || []) as ContextSegmentType[];
+  const segments = normalizeSegments(data);
 
   const handleCreate = () => {
     if (!title.trim() || !isValidDateRange) {

--- a/src/Days/PostList/PostCreate/ContextSegmentsPanel.tsx
+++ b/src/Days/PostList/PostCreate/ContextSegmentsPanel.tsx
@@ -1,0 +1,325 @@
+import React from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Chip,
+  Stack,
+  TextField,
+  Typography,
+} from '@mui/material';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import dayjs from 'dayjs';
+import {
+  deleteContextSegment,
+  getContextSegments,
+  patchContextSegment,
+  postContextSegment,
+  splitContextSegment,
+} from '../../../../shared/api/routes';
+import { ContextSegmentType } from '../../../../shared/types';
+
+type Props = {
+  date: string;
+};
+
+const ContextSegmentsPanel = ({ date }: Props) => {
+  const queryClient = useQueryClient();
+  const queryKey = ['context_segments', date];
+  const [title, setTitle] = React.useState('');
+  const [details, setDetails] = React.useState('');
+  const [startDate, setStartDate] = React.useState(date);
+  const [endDate, setEndDate] = React.useState('');
+
+  React.useEffect(() => {
+    setStartDate(date);
+  }, [date]);
+
+  const { data } = useQuery(queryKey, () => getContextSegments({ date }));
+
+  const refreshData = () => {
+    queryClient.invalidateQueries(queryKey);
+    queryClient.invalidateQueries(['recent_posts']);
+    queryClient.invalidateQueries(['history_posts']);
+  };
+
+  const createMutation = useMutation(postContextSegment, {
+    onSuccess: () => {
+      setTitle('');
+      setDetails('');
+      setEndDate('');
+      refreshData();
+    },
+  });
+
+  const editMutation = useMutation(
+    ({
+      id,
+      data,
+    }: {
+      id: number;
+      data: {
+        title?: string;
+        details?: string;
+        start_date?: string;
+        end_date?: string | null;
+      };
+    }) => patchContextSegment(id, data),
+    {
+      onSuccess: refreshData,
+    },
+  );
+
+  const splitMutation = useMutation(
+    ({
+      id,
+      data,
+    }: {
+      id: number;
+      data: {
+        splitDate: string;
+        newTitle?: string;
+        newDetails?: string;
+      };
+    }) => splitContextSegment(id, data),
+    {
+      onSuccess: refreshData,
+    },
+  );
+
+  const deleteMutation = useMutation((id: number) => deleteContextSegment(id), {
+    onSuccess: refreshData,
+  });
+
+  const isValidDateRange = !endDate || endDate >= startDate;
+  const isBusy =
+    createMutation.isLoading ||
+    editMutation.isLoading ||
+    splitMutation.isLoading ||
+    deleteMutation.isLoading;
+
+  const segments = (data || []) as ContextSegmentType[];
+
+  const handleCreate = () => {
+    if (!title.trim() || !isValidDateRange) {
+      return;
+    }
+    createMutation.mutate({
+      title: title.trim(),
+      details: details.trim(),
+      start_date: startDate,
+      end_date: endDate || null,
+    });
+  };
+
+  const handleEdit = (segment: ContextSegmentType) => {
+    const newTitle = window.prompt('Title', segment.title);
+    if (newTitle === null || !newTitle.trim()) {
+      return;
+    }
+    const newDetails = window.prompt('Details', segment.details || '');
+    if (newDetails === null) {
+      return;
+    }
+    const newStartDate = window.prompt(
+      'Start date (YYYY-MM-DD)',
+      segment.start_date,
+    );
+    if (!newStartDate) {
+      return;
+    }
+    const currentEndDate = segment.end_date || '';
+    const newEndDate = window.prompt(
+      'End date (YYYY-MM-DD) or empty',
+      currentEndDate,
+    );
+    if (newEndDate === null) {
+      return;
+    }
+    const normalizedEndDate = newEndDate.trim() || null;
+    if (normalizedEndDate && normalizedEndDate < newStartDate) {
+      return;
+    }
+
+    editMutation.mutate({
+      id: segment.id,
+      data: {
+        title: newTitle.trim(),
+        details: newDetails,
+        start_date: newStartDate,
+        end_date: normalizedEndDate,
+      },
+    });
+  };
+
+  const handleSplit = (segment: ContextSegmentType) => {
+    const splitDate = window.prompt('Split from date (YYYY-MM-DD)', date);
+    if (!splitDate) {
+      return;
+    }
+    const newTitle = window.prompt('New title', segment.title);
+    if (newTitle === null || !newTitle.trim()) {
+      return;
+    }
+    const newDetails = window.prompt('New details', segment.details || '');
+    if (newDetails === null) {
+      return;
+    }
+    splitMutation.mutate({
+      id: segment.id,
+      data: {
+        splitDate,
+        newTitle: newTitle.trim(),
+        newDetails,
+      },
+    });
+  };
+
+  const handleDelete = (segmentId: number) => {
+    if (!window.confirm('Delete this context segment?')) {
+      return;
+    }
+    deleteMutation.mutate(segmentId);
+  };
+
+  return (
+    <Box
+      sx={{
+        marginBottom: 2,
+        padding: (theme) => theme.spacing(2),
+        border: (theme) => `1px solid ${theme.palette.divider}`,
+        borderRadius: 1,
+      }}
+    >
+      <Typography variant="subtitle1" sx={{ marginBottom: 1 }}>
+        Active context for {dayjs(date).format('YYYY-MM-DD')}
+      </Typography>
+      {segments.length ? (
+        <Stack spacing={1} sx={{ marginBottom: 2 }}>
+          {segments.map((segment) => (
+            <Box
+              key={segment.id}
+              sx={{
+                border: (theme) => `1px solid ${theme.palette.divider}`,
+                borderRadius: 1,
+                padding: 1,
+              }}
+            >
+              <Box
+                sx={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 1,
+                  flexWrap: 'wrap',
+                }}
+              >
+                <Chip
+                  label={segment.title}
+                  color="primary"
+                  variant="outlined"
+                  title={segment.details}
+                />
+                <Stack direction="row" spacing={1}>
+                  <Button
+                    size="small"
+                    color="inherit"
+                    onClick={() => handleEdit(segment)}
+                    disabled={isBusy}
+                  >
+                    Edit
+                  </Button>
+                  <Button
+                    size="small"
+                    color="inherit"
+                    onClick={() => handleSplit(segment)}
+                    disabled={isBusy}
+                  >
+                    Split
+                  </Button>
+                  <Button
+                    size="small"
+                    color="inherit"
+                    onClick={() => handleDelete(segment.id)}
+                    disabled={isBusy}
+                  >
+                    Delete
+                  </Button>
+                </Stack>
+              </Box>
+              {segment.details ? (
+                <Typography
+                  variant="body2"
+                  sx={{ marginTop: 0.5, whiteSpace: 'pre-wrap' }}
+                >
+                  {segment.details}
+                </Typography>
+              ) : null}
+              <Typography variant="caption" color="text.secondary">
+                {segment.start_date} - {segment.end_date || 'ongoing'}
+              </Typography>
+            </Box>
+          ))}
+        </Stack>
+      ) : (
+        <Typography variant="body2" sx={{ marginBottom: 2 }}>
+          No active context segments on this date.
+        </Typography>
+      )}
+
+      <Typography variant="subtitle2" sx={{ marginBottom: 1 }}>
+        Add context segment
+      </Typography>
+      <Stack spacing={1.5}>
+        <TextField
+          fullWidth
+          label="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          size="small"
+        />
+        <TextField
+          fullWidth
+          multiline
+          minRows={2}
+          label="Details"
+          value={details}
+          onChange={(e) => setDetails(e.target.value)}
+          size="small"
+        />
+        <Stack direction="row" spacing={1.5}>
+          <TextField
+            fullWidth
+            label="Start date"
+            type="date"
+            value={startDate}
+            onChange={(e) => setStartDate(e.target.value)}
+            size="small"
+            InputLabelProps={{ shrink: true }}
+          />
+          <TextField
+            fullWidth
+            label="End date"
+            type="date"
+            value={endDate}
+            onChange={(e) => setEndDate(e.target.value)}
+            size="small"
+            InputLabelProps={{ shrink: true }}
+          />
+        </Stack>
+        {!isValidDateRange ? (
+          <Alert severity="warning">End date cannot be before start date.</Alert>
+        ) : null}
+        <Button
+          variant="outlined"
+          onClick={handleCreate}
+          disabled={isBusy || !title.trim() || !isValidDateRange}
+        >
+          Add context
+        </Button>
+      </Stack>
+    </Box>
+  );
+};
+
+export default ContextSegmentsPanel;

--- a/src/Days/PostList/PostCreate/ContextSegmentsPanel.tsx
+++ b/src/Days/PostList/PostCreate/ContextSegmentsPanel.tsx
@@ -16,8 +16,8 @@ import {
   patchContextSegment,
   postContextSegment,
   splitContextSegment,
-} from '../../../../shared/api/routes';
-import { ContextSegmentType } from '../../../../shared/types';
+} from '../../../shared/api/routes';
+import { ContextSegmentType } from '../../../shared/types';
 
 type Props = {
   date: string;
@@ -308,7 +308,9 @@ const ContextSegmentsPanel = ({ date }: Props) => {
           />
         </Stack>
         {!isValidDateRange ? (
-          <Alert severity="warning">End date cannot be before start date.</Alert>
+          <Alert severity="warning">
+            End date cannot be before start date.
+          </Alert>
         ) : null}
         <Button
           variant="outlined"

--- a/src/Days/PostList/PostCreate/index.tsx
+++ b/src/Days/PostList/PostCreate/index.tsx
@@ -1,13 +1,18 @@
 import React from 'react';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
+import Box from '@mui/material/Box';
+import Chip from '@mui/material/Chip';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
-import { postPost } from '../../../shared/api/routes';
+import Typography from '@mui/material/Typography';
+import { useQuery } from '@tanstack/react-query';
+import { getContextSegments, postPost } from '../../../shared/api/routes';
 import { useCreateMutation } from '../../../shared/hooks/useCreateMutation';
+import { ContextSegmentType } from '../../../shared/types';
 import { dateToMySQLFormat } from '../../../shared/utils/mappers';
 import ContextSegmentsPanel from './ContextSegmentsPanel';
 
@@ -24,6 +29,9 @@ const PostCreate = () => {
   const [value, setValue] = React.useState('');
   const [date, setDate] = React.useState(today);
   const [isContextOpen, setContextOpen] = React.useState(false);
+  const contextQuery = useQuery(['context_segments', date], () =>
+    getContextSegments({ date }),
+  );
   const createPostMutation = useCreateMutation(
     () => postPost(createPost(value, date)),
     ['recent_posts'],
@@ -56,6 +64,7 @@ const PostCreate = () => {
       createPostMutation.mutate(value);
     }
   };
+  const appliedContext = (contextQuery.data || []) as ContextSegmentType[];
 
   return (
     <form style={{ marginBottom: '30px', textAlign: 'center' }}>
@@ -97,6 +106,37 @@ const PostCreate = () => {
       >
         Today
       </Button>
+      <Box
+        sx={{
+          marginTop: 1.5,
+          marginBottom: 1,
+          textAlign: 'left',
+        }}
+      >
+        <Typography
+          variant="body2"
+          color="text.secondary"
+          sx={{ marginBottom: 1 }}
+        >
+          Applied context
+        </Typography>
+        {appliedContext.length ? (
+          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+            {appliedContext.map((segment) => (
+              <Chip
+                key={segment.id}
+                label={segment.title}
+                variant="outlined"
+                size="small"
+              />
+            ))}
+          </Box>
+        ) : (
+          <Typography variant="body2" color="text.secondary">
+            No context on this date.
+          </Typography>
+        )}
+      </Box>
       <Button
         type="button"
         color="inherit"

--- a/src/Days/PostList/PostCreate/index.tsx
+++ b/src/Days/PostList/PostCreate/index.tsx
@@ -7,15 +7,22 @@ import Chip from '@mui/material/Chip';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
 import IconButton from '@mui/material/IconButton';
-import { useQuery } from '@tanstack/react-query';
-import { getContextSegments, postPost } from '../../../shared/api/routes';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  deleteContextSegment,
+  getContextSegments,
+  patchContextSegment,
+  postContextSegment,
+  postPost,
+  splitContextSegment,
+} from '../../../shared/api/routes';
 import { useCreateMutation } from '../../../shared/hooks/useCreateMutation';
 import { ContextSegmentType } from '../../../shared/types';
 import { dateToMySQLFormat } from '../../../shared/utils/mappers';
-import ContextSegmentsPanel from './ContextSegmentsPanel';
 
 dayjs.extend(utc);
 
@@ -36,11 +43,82 @@ const normalizeSegments = (val: any): ContextSegmentType[] => {
 };
 
 const PostCreate = () => {
+  const queryClient = useQueryClient();
   const [value, setValue] = React.useState('');
   const [date, setDate] = React.useState(today);
-  const [isContextOpen, setContextOpen] = React.useState(false);
+  const [isAddContextOpen, setAddContextOpen] = React.useState(false);
+  const [selectedContext, setSelectedContext] =
+    React.useState<ContextSegmentType | null>(null);
+  const [title, setTitle] = React.useState('');
+  const [details, setDetails] = React.useState('');
+  const [startDate, setStartDate] = React.useState(today);
+  const [endDate, setEndDate] = React.useState('');
+  const [splitDate, setSplitDate] = React.useState(today);
   const contextQuery = useQuery(['context_segments', date], () =>
     getContextSegments({ date }),
+  );
+  const refreshContextData = () => {
+    queryClient.invalidateQueries(['context_segments', date]);
+    queryClient.invalidateQueries(['recent_posts']);
+    queryClient.invalidateQueries(['history_posts']);
+  };
+  const createContextMutation = useMutation(postContextSegment, {
+    onSuccess: () => {
+      setTitle('');
+      setDetails('');
+      setStartDate(date);
+      setEndDate('');
+      setAddContextOpen(false);
+      refreshContextData();
+    },
+  });
+  const editContextMutation = useMutation(
+    ({
+      id,
+      data,
+    }: {
+      id: number;
+      data: {
+        title?: string;
+        details?: string;
+        start_date?: string;
+        end_date?: string | null;
+      };
+    }) => patchContextSegment(id, data),
+    {
+      onSuccess: () => {
+        setSelectedContext(null);
+        refreshContextData();
+      },
+    },
+  );
+  const splitContextMutation = useMutation(
+    ({
+      id,
+      data,
+    }: {
+      id: number;
+      data: {
+        splitDate: string;
+        newTitle?: string;
+        newDetails?: string;
+      };
+    }) => splitContextSegment(id, data),
+    {
+      onSuccess: () => {
+        setSelectedContext(null);
+        refreshContextData();
+      },
+    },
+  );
+  const deleteContextMutation = useMutation(
+    (id: number) => deleteContextSegment(id),
+    {
+      onSuccess: () => {
+        setSelectedContext(null);
+        refreshContextData();
+      },
+    },
   );
   const createPostMutation = useCreateMutation(
     () => postPost(createPost(value, date)),
@@ -74,6 +152,65 @@ const PostCreate = () => {
       createPostMutation.mutate(value);
     }
   };
+  const isValidDateRange = !endDate || endDate >= startDate;
+  const handleCreateContext = () => {
+    if (!title.trim() || !isValidDateRange) {
+      return;
+    }
+    createContextMutation.mutate({
+      title: title.trim(),
+      details: details.trim(),
+      start_date: startDate,
+      end_date: endDate || null,
+    });
+  };
+  const openContextDialog = (segment: ContextSegmentType) => {
+    setSelectedContext(segment);
+    setTitle(segment.title || '');
+    setDetails(segment.details || '');
+    setStartDate(segment.start_date || date);
+    setEndDate(segment.end_date || '');
+    setSplitDate(date);
+  };
+  const handleEditContext = () => {
+    if (!selectedContext || !title.trim()) {
+      return;
+    }
+    if (endDate && endDate < startDate) {
+      return;
+    }
+    editContextMutation.mutate({
+      id: selectedContext.id,
+      data: {
+        title: title.trim(),
+        details,
+        start_date: startDate,
+        end_date: endDate || null,
+      },
+    });
+  };
+  const handleSplitContext = () => {
+    if (!selectedContext || !splitDate) {
+      return;
+    }
+    splitContextMutation.mutate({
+      id: selectedContext.id,
+      data: {
+        splitDate,
+        newTitle: title.trim() || selectedContext.title,
+        newDetails: details,
+      },
+    });
+  };
+  const handleDeleteContext = () => {
+    if (!selectedContext) {
+      return;
+    }
+    if (!window.confirm('Delete this context segment?')) {
+      return;
+    }
+    deleteContextMutation.mutate(selectedContext.id);
+  };
   const appliedContext = normalizeSegments(contextQuery.data);
 
   return (
@@ -103,9 +240,20 @@ const PostCreate = () => {
             label={segment.title}
             variant="outlined"
             size="small"
+            clickable
+            onClick={() => openContextDialog(segment)}
           />
         ))}
-        <IconButton size="small" onClick={() => setContextOpen(true)}>
+        <IconButton
+          size="small"
+          onClick={() => {
+            setTitle('');
+            setDetails('');
+            setStartDate(date);
+            setEndDate('');
+            setAddContextOpen(true);
+          }}
+        >
           <AddIcon fontSize="small" />
         </IconButton>
       </Box>
@@ -117,15 +265,133 @@ const PostCreate = () => {
         variant="standard"
       />
       <Dialog
-        open={isContextOpen}
-        onClose={() => setContextOpen(false)}
+        open={isAddContextOpen}
+        onClose={() => setAddContextOpen(false)}
         fullWidth
-        maxWidth="md"
+        maxWidth="sm"
       >
-        <DialogTitle>Context</DialogTitle>
+        <DialogTitle>Add context</DialogTitle>
         <DialogContent>
-          <ContextSegmentsPanel date={date} />
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 1.5,
+              marginTop: 1,
+            }}
+          >
+            <TextField
+              label="Title"
+              size="small"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+            <TextField
+              label="Details"
+              size="small"
+              multiline
+              minRows={2}
+              value={details}
+              onChange={(e) => setDetails(e.target.value)}
+            />
+            <TextField
+              label="Start date"
+              type="date"
+              size="small"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              InputLabelProps={{ shrink: true }}
+            />
+            <TextField
+              label="End date"
+              type="date"
+              size="small"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+              InputLabelProps={{ shrink: true }}
+            />
+          </Box>
         </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setAddContextOpen(false)} color="inherit">
+            Cancel
+          </Button>
+          <Button
+            onClick={handleCreateContext}
+            variant="contained"
+            disabled={!title.trim() || !isValidDateRange}
+          >
+            Save
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <Dialog
+        open={!!selectedContext}
+        onClose={() => setSelectedContext(null)}
+        fullWidth
+        maxWidth="sm"
+      >
+        <DialogTitle>Context details</DialogTitle>
+        <DialogContent>
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 1.5,
+              marginTop: 1,
+            }}
+          >
+            <TextField
+              label="Title"
+              size="small"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+            />
+            <TextField
+              label="Details"
+              size="small"
+              multiline
+              minRows={2}
+              value={details}
+              onChange={(e) => setDetails(e.target.value)}
+            />
+            <TextField
+              label="Start date"
+              type="date"
+              size="small"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              InputLabelProps={{ shrink: true }}
+            />
+            <TextField
+              label="End date"
+              type="date"
+              size="small"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+              InputLabelProps={{ shrink: true }}
+            />
+            <TextField
+              label="Split from date"
+              type="date"
+              size="small"
+              value={splitDate}
+              onChange={(e) => setSplitDate(e.target.value)}
+              InputLabelProps={{ shrink: true }}
+            />
+          </Box>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleDeleteContext} color="inherit">
+            Delete
+          </Button>
+          <Button onClick={handleSplitContext} color="inherit">
+            Split
+          </Button>
+          <Button onClick={handleEditContext} variant="contained">
+            Save
+          </Button>
+        </DialogActions>
       </Dialog>
       <Button
         fullWidth

--- a/src/Days/PostList/PostCreate/index.tsx
+++ b/src/Days/PostList/PostCreate/index.tsx
@@ -3,6 +3,9 @@ import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogContent from '@mui/material/DialogContent';
+import DialogTitle from '@mui/material/DialogTitle';
 import { postPost } from '../../../shared/api/routes';
 import { useCreateMutation } from '../../../shared/hooks/useCreateMutation';
 import { dateToMySQLFormat } from '../../../shared/utils/mappers';
@@ -20,6 +23,7 @@ const createPost = (body: string, date: string) => ({
 const PostCreate = () => {
   const [value, setValue] = React.useState('');
   const [date, setDate] = React.useState(today);
+  const [isContextOpen, setContextOpen] = React.useState(false);
   const createPostMutation = useCreateMutation(
     () => postPost(createPost(value, date)),
     ['recent_posts'],
@@ -65,6 +69,7 @@ const PostCreate = () => {
       />
       <Button
         style={{ marginRight: 15 }}
+        type="button"
         onClick={() =>
           handleDate({
             target: { value: yesterday },
@@ -82,6 +87,7 @@ const PostCreate = () => {
         variant="standard"
       />
       <Button
+        type="button"
         onClick={() =>
           handleDate({
             target: { value: today },
@@ -91,9 +97,27 @@ const PostCreate = () => {
       >
         Today
       </Button>
-      <ContextSegmentsPanel date={date} />
+      <Button
+        type="button"
+        color="inherit"
+        onClick={() => setContextOpen(true)}
+      >
+        Add context
+      </Button>
+      <Dialog
+        open={isContextOpen}
+        onClose={() => setContextOpen(false)}
+        fullWidth
+        maxWidth="md"
+      >
+        <DialogTitle>Context</DialogTitle>
+        <DialogContent>
+          <ContextSegmentsPanel date={date} />
+        </DialogContent>
+      </Dialog>
       <Button
         fullWidth
+        type="button"
         variant="contained"
         color="primary"
         onClick={handleSubmit}

--- a/src/Days/PostList/PostCreate/index.tsx
+++ b/src/Days/PostList/PostCreate/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
+import AddIcon from '@mui/icons-material/Add';
 import Box from '@mui/material/Box';
 import Chip from '@mui/material/Chip';
 import TextField from '@mui/material/TextField';
@@ -8,7 +9,7 @@ import Button from '@mui/material/Button';
 import Dialog from '@mui/material/Dialog';
 import DialogContent from '@mui/material/DialogContent';
 import DialogTitle from '@mui/material/DialogTitle';
-import Typography from '@mui/material/Typography';
+import IconButton from '@mui/material/IconButton';
 import { useQuery } from '@tanstack/react-query';
 import { getContextSegments, postPost } from '../../../shared/api/routes';
 import { useCreateMutation } from '../../../shared/hooks/useCreateMutation';
@@ -19,7 +20,6 @@ import ContextSegmentsPanel from './ContextSegmentsPanel';
 dayjs.extend(utc);
 
 const today = dayjs().format('YYYY-MM-DD');
-const yesterday = dayjs().subtract(1, 'days').format('YYYY-MM-DD');
 const createPost = (body: string, date: string) => ({
   body,
   date: dateToMySQLFormat(date),
@@ -86,74 +86,36 @@ const PostCreate = () => {
         value={value}
         onChange={handleText}
       />
-      <Button
-        style={{ marginRight: 15 }}
-        type="button"
-        onClick={() =>
-          handleDate({
-            target: { value: yesterday },
-          } as React.ChangeEvent<HTMLInputElement>)
-        }
-        color="inherit"
-      >
-        Yesterday
-      </Button>
-      <TextField
-        style={{ marginRight: 15 }}
-        type="date"
-        value={date}
-        onChange={handleDate}
-        variant="standard"
-      />
-      <Button
-        type="button"
-        onClick={() =>
-          handleDate({
-            target: { value: today },
-          } as React.ChangeEvent<HTMLInputElement>)
-        }
-        color="inherit"
-      >
-        Today
-      </Button>
       <Box
         sx={{
           marginTop: 1.5,
           marginBottom: 1,
           textAlign: 'left',
+          display: 'flex',
+          gap: 1,
+          flexWrap: 'wrap',
+          alignItems: 'center',
         }}
       >
-        <Typography
-          variant="body2"
-          color="text.secondary"
-          sx={{ marginBottom: 1 }}
-        >
-          Applied context
-        </Typography>
-        {appliedContext.length ? (
-          <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
-            {appliedContext.map((segment) => (
-              <Chip
-                key={segment.id}
-                label={segment.title}
-                variant="outlined"
-                size="small"
-              />
-            ))}
-          </Box>
-        ) : (
-          <Typography variant="body2" color="text.secondary">
-            No context on this date.
-          </Typography>
-        )}
+        {appliedContext.map((segment) => (
+          <Chip
+            key={segment.id}
+            label={segment.title}
+            variant="outlined"
+            size="small"
+          />
+        ))}
+        <IconButton size="small" onClick={() => setContextOpen(true)}>
+          <AddIcon fontSize="small" />
+        </IconButton>
       </Box>
-      <Button
-        type="button"
-        color="inherit"
-        onClick={() => setContextOpen(true)}
-      >
-        Add context
-      </Button>
+      <TextField
+        style={{ marginBottom: 10 }}
+        type="date"
+        value={date}
+        onChange={handleDate}
+        variant="standard"
+      />
       <Dialog
         open={isContextOpen}
         onClose={() => setContextOpen(false)}

--- a/src/Days/PostList/PostCreate/index.tsx
+++ b/src/Days/PostList/PostCreate/index.tsx
@@ -253,6 +253,13 @@ const PostCreate = () => {
             size="small"
             clickable
             onClick={() => openContextDialog(segment)}
+            sx={{
+              borderColor: (theme) => theme.palette.primary.main,
+              color: (theme) => theme.palette.text.primary,
+              '&:hover': {
+                borderColor: (theme) => theme.palette.primary.main,
+              },
+            }}
           />
         ))}
         <IconButton

--- a/src/Days/PostList/PostCreate/index.tsx
+++ b/src/Days/PostList/PostCreate/index.tsx
@@ -6,6 +6,7 @@ import Button from '@mui/material/Button';
 import { postPost } from '../../../shared/api/routes';
 import { useCreateMutation } from '../../../shared/hooks/useCreateMutation';
 import { dateToMySQLFormat } from '../../../shared/utils/mappers';
+import ContextSegmentsPanel from './ContextSegmentsPanel';
 
 dayjs.extend(utc);
 
@@ -23,7 +24,14 @@ const PostCreate = () => {
     () => postPost(createPost(value, date)),
     ['recent_posts'],
     (old: any[]) => [
-      { ...createPost(value, date), id: 0, labels: [], comments: [] },
+      {
+        ...createPost(value, date),
+        id: 0,
+        labels: [],
+        comments: [],
+        periods: [],
+        context_segments: [],
+      },
       ...old,
     ],
     () => {
@@ -83,6 +91,7 @@ const PostCreate = () => {
       >
         Today
       </Button>
+      <ContextSegmentsPanel date={date} />
       <Button
         fullWidth
         variant="contained"

--- a/src/Days/PostList/PostCreate/index.tsx
+++ b/src/Days/PostList/PostCreate/index.tsx
@@ -32,6 +32,17 @@ const createPost = (body: string, date: string) => ({
   date: dateToMySQLFormat(date),
 });
 
+const toInputDate = (value?: string | null): string => {
+  if (!value) {
+    return '';
+  }
+  const normalized = dayjs(value);
+  if (normalized.isValid()) {
+    return normalized.format('YYYY-MM-DD');
+  }
+  return value.slice(0, 10);
+};
+
 const normalizeSegments = (val: any): ContextSegmentType[] => {
   if (Array.isArray(val)) {
     return val;
@@ -168,9 +179,9 @@ const PostCreate = () => {
     setSelectedContext(segment);
     setTitle(segment.title || '');
     setDetails(segment.details || '');
-    setStartDate(segment.start_date || date);
-    setEndDate(segment.end_date || '');
-    setSplitDate(date);
+    setStartDate(toInputDate(segment.start_date) || toInputDate(date));
+    setEndDate(toInputDate(segment.end_date));
+    setSplitDate(toInputDate(date));
   };
   const handleEditContext = () => {
     if (!selectedContext || !title.trim()) {

--- a/src/Days/PostList/PostCreate/index.tsx
+++ b/src/Days/PostList/PostCreate/index.tsx
@@ -25,6 +25,16 @@ const createPost = (body: string, date: string) => ({
   date: dateToMySQLFormat(date),
 });
 
+const normalizeSegments = (val: any): ContextSegmentType[] => {
+  if (Array.isArray(val)) {
+    return val;
+  }
+  if (Array.isArray(val?.data)) {
+    return val.data;
+  }
+  return [];
+};
+
 const PostCreate = () => {
   const [value, setValue] = React.useState('');
   const [date, setDate] = React.useState(today);
@@ -64,7 +74,7 @@ const PostCreate = () => {
       createPostMutation.mutate(value);
     }
   };
-  const appliedContext = (contextQuery.data || []) as ContextSegmentType[];
+  const appliedContext = normalizeSegments(contextQuery.data);
 
   return (
     <form style={{ marginBottom: '30px', textAlign: 'center' }}>

--- a/src/Days/PostList/Posts/index.tsx
+++ b/src/Days/PostList/Posts/index.tsx
@@ -12,9 +12,10 @@ type Props = {
 };
 
 const Posts = ({ labels, posts, searchTerm, invalidateQueries }: Props) => {
+  const safePosts = Array.isArray(posts) ? posts : [];
   return (
     <Grid container direction="column" spacing={4}>
-      {posts.map((p) => (
+      {safePosts.map((p) => (
         <Grid item key={p.id}>
           <PostShow
             post={{ ...p, labels: p.labels || [] }}

--- a/src/Days/PostList/index.tsx
+++ b/src/Days/PostList/index.tsx
@@ -27,6 +27,11 @@ const PostList = ({ tab }: Props) => {
     tab === 'history' ? () => getPostsHistoryByDate(md) : getPosts,
   );
   const labelsData = useQuery(['labels'], getLabels);
+  const posts = Array.isArray(data)
+    ? data
+    : Array.isArray((data as any)?.data)
+    ? (data as any).data
+    : [];
 
   return (
     <>
@@ -37,7 +42,7 @@ const PostList = ({ tab }: Props) => {
         <Typography>Loading...</Typography>
       ) : (
         <Posts
-          posts={data}
+          posts={posts}
           labels={labelsData.data || []}
           invalidateQueries={queryKey}
         />

--- a/src/Days/PostShow/index.tsx
+++ b/src/Days/PostShow/index.tsx
@@ -6,10 +6,11 @@ import Chip from '@mui/material/Chip';
 import Grid from '@mui/material/Grid';
 import Button from '@mui/material/Button';
 import { Box, Paper, TextField } from '@mui/material';
-import { QueryKey } from '@tanstack/react-query';
+import { QueryKey, useQuery } from '@tanstack/react-query';
 import PostLabel from '../PostLabel';
 import {
   addLabelToPost,
+  getContextSegments,
   deleteLabelFromPost,
   deletePost,
   editPost,
@@ -39,6 +40,13 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
   const [isEdit, setIsEdit] = React.useState(false);
   const [updateDate, setUpdateDate] = React.useState(
     dayjs(post.date.slice(0, 10)).format('YYYY-MM-DD'),
+  );
+  const contextByDate = useQuery(
+    ['context_segments', post.id, post.date?.slice(0, 10)],
+    () => getContextSegments({ date: post.date?.slice(0, 10) }),
+    {
+      enabled: !post.context_segments?.length && !!post.date,
+    },
   );
   const deletePostMutation = useDeleteMutation(
     () => deletePost(post.id),
@@ -108,6 +116,13 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
       </span>
     );
   };
+  const contextSegments = post.context_segments?.length
+    ? post.context_segments
+    : Array.isArray(contextByDate.data)
+    ? contextByDate.data
+    : Array.isArray((contextByDate.data as any)?.data)
+    ? (contextByDate.data as any).data
+    : [];
 
   return (
     <Box
@@ -291,9 +306,9 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
                 ))}
               </Grid>
             ) : null}
-            {post.context_segments && post.context_segments.length > 0 ? (
+            {contextSegments.length > 0 ? (
               <Grid container flexWrap="wrap" gap={1} sx={{ marginTop: 1 }}>
-                {post.context_segments.map((segment) => (
+                {contextSegments.map((segment) => (
                   <Grid item key={segment.id}>
                     <Chip
                       label={segment.title}

--- a/src/Days/PostShow/index.tsx
+++ b/src/Days/PostShow/index.tsx
@@ -5,15 +5,31 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import Chip from '@mui/material/Chip';
 import Grid from '@mui/material/Grid';
 import Button from '@mui/material/Button';
-import { Box, Paper, TextField } from '@mui/material';
-import { QueryKey, useQuery } from '@tanstack/react-query';
+import {
+  Box,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Paper,
+  TextField,
+} from '@mui/material';
+import {
+  QueryKey,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import PostLabel from '../PostLabel';
 import {
   addLabelToPost,
+  deleteContextSegment,
   getContextSegments,
+  patchContextSegment,
   deleteLabelFromPost,
   deletePost,
   editPost,
+  splitContextSegment,
 } from '../../shared/api/routes';
 import { useUpdateMutation } from '../../shared/hooks/useUpdateMutation';
 import { useDeleteMutation } from '../../shared/hooks/useDeleteMutation';
@@ -37,9 +53,17 @@ type Props = {
 const toDateOnly = (value: string | Date) => dayjs(value).format('YYYY-MM-DD');
 
 const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
+  const queryClient = useQueryClient();
   const [deleteMode, setDeletedMode] = React.useState(false);
   const [isCommentOpen, setCommentOpen] = React.useState(false);
   const [isEdit, setIsEdit] = React.useState(false);
+  const [selectedContext, setSelectedContext] =
+    React.useState<ContextSegmentType | null>(null);
+  const [title, setTitle] = React.useState('');
+  const [details, setDetails] = React.useState('');
+  const [startDate, setStartDate] = React.useState('');
+  const [endDate, setEndDate] = React.useState('');
+  const [splitDate, setSplitDate] = React.useState('');
   const postDate = toDateOnly(post.date);
   const [updateDate, setUpdateDate] = React.useState(postDate);
   const contextByDate = useQuery(
@@ -81,6 +105,58 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
     }),
     () => setIsEdit(false),
   );
+  const refreshContextData = () => {
+    queryClient.invalidateQueries(invalidateQueries);
+    queryClient.invalidateQueries(['context_segments', post.id, postDate]);
+  };
+  const editContextMutation = useMutation(
+    ({
+      id,
+      data,
+    }: {
+      id: number;
+      data: {
+        title?: string;
+        details?: string;
+        start_date?: string;
+        end_date?: string | null;
+      };
+    }) => patchContextSegment(id, data),
+    {
+      onSuccess: () => {
+        setSelectedContext(null);
+        refreshContextData();
+      },
+    },
+  );
+  const splitContextMutation = useMutation(
+    ({
+      id,
+      data,
+    }: {
+      id: number;
+      data: {
+        splitDate: string;
+        newTitle?: string;
+        newDetails?: string;
+      };
+    }) => splitContextSegment(id, data),
+    {
+      onSuccess: () => {
+        setSelectedContext(null);
+        refreshContextData();
+      },
+    },
+  );
+  const deleteContextMutation = useMutation(
+    (id: number) => deleteContextSegment(id),
+    {
+      onSuccess: () => {
+        setSelectedContext(null);
+        refreshContextData();
+      },
+    },
+  );
 
   const toggleDeleteMode = () => {
     setDeletedMode(!deleteMode);
@@ -89,6 +165,55 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
   const handleSubmit = (e: FormEvent, updateText: string) => {
     e.preventDefault();
     editPostMutation.mutate(updateText);
+  };
+  const toInputDate = (value?: string | null) =>
+    value ? toDateOnly(value) : '';
+  const openContextDialog = (segment: ContextSegmentType) => {
+    setSelectedContext(segment);
+    setTitle(segment.title || '');
+    setDetails(segment.details || '');
+    setStartDate(toInputDate(segment.start_date));
+    setEndDate(toInputDate(segment.end_date));
+    setSplitDate(postDate);
+  };
+  const handleEditContext = () => {
+    if (!selectedContext || !title.trim()) {
+      return;
+    }
+    if (endDate && endDate < startDate) {
+      return;
+    }
+    editContextMutation.mutate({
+      id: selectedContext.id,
+      data: {
+        title: title.trim(),
+        details,
+        start_date: startDate,
+        end_date: endDate || null,
+      },
+    });
+  };
+  const handleSplitContext = () => {
+    if (!selectedContext || !splitDate) {
+      return;
+    }
+    splitContextMutation.mutate({
+      id: selectedContext.id,
+      data: {
+        splitDate,
+        newTitle: title.trim() || selectedContext.title,
+        newDetails: details,
+      },
+    });
+  };
+  const handleDeleteContext = () => {
+    if (!selectedContext) {
+      return;
+    }
+    if (!window.confirm('Delete this context segment?')) {
+      return;
+    }
+    deleteContextMutation.mutate(selectedContext.id);
   };
 
   const getHighlightedText = (text: string, highlight: string) => {
@@ -314,6 +439,8 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
                     <Chip
                       label={segment.title}
                       title={segment.details}
+                      clickable
+                      onClick={() => openContextDialog(segment)}
                       sx={{
                         color: (theme) => theme.palette.secondary.main,
                       }}
@@ -338,6 +465,74 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
             ) : (
               ''
             )}
+            <Dialog
+              open={!!selectedContext}
+              onClose={() => setSelectedContext(null)}
+              fullWidth
+              maxWidth="sm"
+            >
+              <DialogTitle>Context details</DialogTitle>
+              <DialogContent>
+                <Box
+                  sx={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 1.5,
+                    marginTop: 1,
+                  }}
+                >
+                  <TextField
+                    label="Title"
+                    size="small"
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                  />
+                  <TextField
+                    label="Details"
+                    size="small"
+                    multiline
+                    minRows={2}
+                    value={details}
+                    onChange={(e) => setDetails(e.target.value)}
+                  />
+                  <TextField
+                    label="Start date"
+                    type="date"
+                    size="small"
+                    value={startDate}
+                    onChange={(e) => setStartDate(e.target.value)}
+                    InputLabelProps={{ shrink: true }}
+                  />
+                  <TextField
+                    label="End date"
+                    type="date"
+                    size="small"
+                    value={endDate}
+                    onChange={(e) => setEndDate(e.target.value)}
+                    InputLabelProps={{ shrink: true }}
+                  />
+                  <TextField
+                    label="Split from date"
+                    type="date"
+                    size="small"
+                    value={splitDate}
+                    onChange={(e) => setSplitDate(e.target.value)}
+                    InputLabelProps={{ shrink: true }}
+                  />
+                </Box>
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={handleDeleteContext} color="inherit">
+                  Delete
+                </Button>
+                <Button onClick={handleSplitContext} color="inherit">
+                  Split
+                </Button>
+                <Button onClick={handleEditContext} variant="contained">
+                  Save
+                </Button>
+              </DialogActions>
+            </Dialog>
           </Box>
         )}
       </Paper>

--- a/src/Days/PostShow/index.tsx
+++ b/src/Days/PostShow/index.tsx
@@ -17,7 +17,7 @@ import {
 } from '../../shared/api/routes';
 import { useUpdateMutation } from '../../shared/hooks/useUpdateMutation';
 import { useDeleteMutation } from '../../shared/hooks/useDeleteMutation';
-import { LabelType, PostType } from '../../shared/types';
+import { ContextSegmentType, LabelType, PostType } from '../../shared/types';
 import { dateToMySQLFormat } from '../../shared/utils/mappers';
 import PostEdit from './PostEdit';
 import PostComment from './PostComment';
@@ -116,12 +116,12 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
       </span>
     );
   };
-  const contextSegments = post.context_segments?.length
+  const contextSegments: ContextSegmentType[] = post.context_segments?.length
     ? post.context_segments
     : Array.isArray(contextByDate.data)
-    ? contextByDate.data
+    ? (contextByDate.data as ContextSegmentType[])
     : Array.isArray((contextByDate.data as any)?.data)
-    ? (contextByDate.data as any).data
+    ? ((contextByDate.data as any).data as ContextSegmentType[])
     : [];
 
   return (

--- a/src/Days/PostShow/index.tsx
+++ b/src/Days/PostShow/index.tsx
@@ -34,16 +34,17 @@ type Props = {
   invalidateQueries: QueryKey;
 };
 
+const toDateOnly = (value: string | Date) => dayjs(value).format('YYYY-MM-DD');
+
 const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
   const [deleteMode, setDeletedMode] = React.useState(false);
   const [isCommentOpen, setCommentOpen] = React.useState(false);
   const [isEdit, setIsEdit] = React.useState(false);
-  const [updateDate, setUpdateDate] = React.useState(
-    dayjs(post.date.slice(0, 10)).format('YYYY-MM-DD'),
-  );
+  const postDate = toDateOnly(post.date);
+  const [updateDate, setUpdateDate] = React.useState(postDate);
   const contextByDate = useQuery(
-    ['context_segments', post.id, post.date?.slice(0, 10)],
-    () => getContextSegments({ date: post.date?.slice(0, 10) }),
+    ['context_segments', post.id, postDate],
+    () => getContextSegments({ date: postDate }),
     {
       enabled: !post.context_segments?.length && !!post.date,
     },
@@ -161,7 +162,7 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
                 variant="standard"
               />
             ) : (
-              dayjs(post.date.slice(0, 10)).format('dddd YYYY-MM-DD')
+              dayjs(postDate).format('dddd YYYY-MM-DD')
             )}
           </Grid>
           <Grid item>

--- a/src/Days/PostShow/index.tsx
+++ b/src/Days/PostShow/index.tsx
@@ -442,7 +442,11 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
                       clickable
                       onClick={() => openContextDialog(segment)}
                       sx={{
-                        color: (theme) => theme.palette.secondary.main,
+                        borderColor: (theme) => theme.palette.primary.main,
+                        color: (theme) => theme.palette.text.primary,
+                        '&:hover': {
+                          borderColor: (theme) => theme.palette.primary.main,
+                        },
                       }}
                       variant="outlined"
                     />

--- a/src/Days/PostShow/index.tsx
+++ b/src/Days/PostShow/index.tsx
@@ -291,6 +291,22 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
                 ))}
               </Grid>
             ) : null}
+            {post.context_segments && post.context_segments.length > 0 ? (
+              <Grid container flexWrap="wrap" gap={1} sx={{ marginTop: 1 }}>
+                {post.context_segments.map((segment) => (
+                  <Grid item key={segment.id}>
+                    <Chip
+                      label={segment.title}
+                      title={segment.details}
+                      sx={{
+                        color: (theme) => theme.palette.secondary.main,
+                      }}
+                      variant="outlined"
+                    />
+                  </Grid>
+                ))}
+              </Grid>
+            ) : null}
             <PostPhotos date={post.date} />
             {post.comments.map((comment) => (
               <PostComment key={comment.id} comment={comment} />

--- a/src/shared/api/routes.ts
+++ b/src/shared/api/routes.ts
@@ -116,6 +116,47 @@ export const editPost = (id: number, data: any) =>
 export const postComment = (data: any) => apiLocalPostRequest(`comments`, data);
 export const postPost = (data: any) =>
   apiLocalPostRequest(`posts`, data).then((resp) => resp.data);
+export const getContextSegments = ({
+  date,
+}: {
+  date?: string;
+} = {}) => {
+  const query = date ? `?active=1&date=${encodeURIComponent(date)}` : '';
+  return apiLocalGetRequest(`context-segments${query}`).then(
+    (resp) => resp.data?.data || resp.data,
+  );
+};
+export const postContextSegment = (data: {
+  title: string;
+  details: string;
+  start_date: string;
+  end_date: string | null;
+}) =>
+  apiLocalPostRequest('context-segments', data).then((resp) => resp.data);
+export const patchContextSegment = (
+  id: number,
+  data: {
+    title?: string;
+    details?: string;
+    start_date?: string;
+    end_date?: string | null;
+  },
+) =>
+  apiLocalPatchRequest(`context-segments/${id}`, data).then((resp) => resp.data);
+export const splitContextSegment = (
+  id: number,
+  data: {
+    splitDate: string;
+    newTitle?: string;
+    newDetails?: string;
+  },
+) =>
+  apiLocalPatchRequest(`context-segments/${id}`, {
+    mode: 'split',
+    ...data,
+  }).then((resp) => resp.data);
+export const deleteContextSegment = (id: number) =>
+  apiLocalDeleteRequest(`context-segments/${id}`).then((resp) => resp.data);
 
 export const getYears = () =>
   apiLocalGetRequest(`posts-history?get=months`).then((resp) =>

--- a/src/shared/api/routes.ts
+++ b/src/shared/api/routes.ts
@@ -249,7 +249,7 @@ export const deleteLT = (id: number) =>
 export const sendLogin = (data: any) =>
   apiPostRequest(`${LOCAL}/authentication`, { ...data, strategy: 'local' });
 export const sendRegistration = (data: any) =>
-  apiPostRequest(`${LOCAL}/register`, data);
+  apiPostRequest(`${LOCAL}/users`, data);
 
 export const getPeriods = () =>
   apiLocalGetRequest(`periods?$limit=200`).then((resp) => resp.data?.data);

--- a/src/shared/api/routes.ts
+++ b/src/shared/api/routes.ts
@@ -131,8 +131,7 @@ export const postContextSegment = (data: {
   details: string;
   start_date: string;
   end_date: string | null;
-}) =>
-  apiLocalPostRequest('context-segments', data).then((resp) => resp.data);
+}) => apiLocalPostRequest('context-segments', data).then((resp) => resp.data);
 export const patchContextSegment = (
   id: number,
   data: {
@@ -142,7 +141,9 @@ export const patchContextSegment = (
     end_date?: string | null;
   },
 ) =>
-  apiLocalPatchRequest(`context-segments/${id}`, data).then((resp) => resp.data);
+  apiLocalPatchRequest(`context-segments/${id}`, data).then(
+    (resp) => resp.data,
+  );
 export const splitContextSegment = (
   id: number,
   data: {

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -21,6 +21,17 @@ export type PostType = {
   comments: CommentType[];
   body: string;
   periods: PeriodType[];
+  context_segments?: ContextSegmentType[];
+};
+
+export type ContextSegmentType = {
+  id: number;
+  title: string;
+  details: string;
+  start_date: string;
+  end_date: string | null;
+  created_at?: string;
+  updated_at?: string;
 };
 
 export type LabelType = {

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import { Server } from 'http';
 import url from 'url';
 import axios from 'axios';


### PR DESCRIPTION
## Summary
This PR introduces reusable **context segments** for diary posts so users can avoid repeating routine details (like schedules, naps, walks) while preserving what was true for a given date in recent posts and Day in History.

## What Changed
- Added a new backend `context_segments` model/service with `title`, `details`, `start_date`, `end_date`, and `user_id`.
- Added API support to:
  - create, edit, and delete context segments
  - fetch active segments by date (`active=1&date=...`)
  - split a segment at a specific date to handle routine changes over time
- Enriched post payloads (`posts` and `posts-history`) with date-matched `context_segments` for each post.
- Updated Post Create UI to show compact context chips and a plus action, with dialogs for:
  - adding a new context segment (form-only add flow)
  - opening an existing segment for edit/split/delete
- Updated Post Show UI to display context chips and make them clickable with the same detail/edit/split/delete flow.
- Updated chip styling to use a blue outline with default text color for consistency.
- Added defensive handling and normalization for date/query shapes to prevent runtime issues (e.g. `map` on undefined, date slicing/type mismatches, HTML date input format issues).

## Why
The task requires reducing repetitive daily writing while still capturing evolving routines over months. Date-ranged, user-defined context segments provide that balance:
- users can maintain small independent context pieces
- posts automatically reflect context active on that date
- history views retain the correct life context for past entries

## Important Implementation Details
- Segment split is implemented via `PATCH` with `mode: 'split'`:
  - original segment is truncated to the day before `splitDate`
  - a new segment is created from `splitDate` onward
  - validation enforces split date within original range
- Date matching for context is performed server-side (`start_date <= post_date <= end_date OR end_date IS NULL`) and ordered by most recent start date.
- Post Show has a fallback date-based context query when a post payload does not include segments, ensuring chips still render.
- Client route updates include explicit context segment APIs and registration/auth flow correction to `/users` + `/authentication`.

This PR was written using [Vibe Kanban](https://vibekanban.com)
