### PR TITLE
Add location-aware on-demand post weather and context segment support (Vibe Kanban)

### DIFF
--- a/server/models/periods.model.ts
+++ b/server/models/periods.model.ts
@@ -13,6 +13,7 @@ export default function (app: Application): Knex {
           table.date('start');
           table.date('end');
           table.boolean('is_location').defaultTo(false);
+          table.string('location_details').nullable();
           table.integer('user_id');
         })
         .then(() => console.log(`Created ${tableName} table`))
@@ -32,6 +33,22 @@ export default function (app: Application): Knex {
             );
         }
       });
+      db.schema
+        .hasColumn(tableName, 'location_details')
+        .then((hasLocationDetails) => {
+          if (!hasLocationDetails) {
+            db.schema
+              .table(tableName, (table) => {
+                table.string('location_details').nullable();
+              })
+              .catch((e) =>
+                console.error(
+                  `Error adding location_details column to ${tableName} table`,
+                  e,
+                ),
+              );
+          }
+        });
     }
   });
   return db;

--- a/server/models/periods.model.ts
+++ b/server/models/periods.model.ts
@@ -12,10 +12,26 @@ export default function (app: Application): Knex {
           table.string('name');
           table.date('start');
           table.date('end');
+          table.boolean('is_location').defaultTo(false);
           table.integer('user_id');
         })
         .then(() => console.log(`Created ${tableName} table`))
         .catch((e) => console.error(`Error creating ${tableName} table`, e));
+    } else {
+      db.schema.hasColumn(tableName, 'is_location').then((hasIsLocation) => {
+        if (!hasIsLocation) {
+          db.schema
+            .table(tableName, (table) => {
+              table.boolean('is_location').defaultTo(false);
+            })
+            .catch((e) =>
+              console.error(
+                `Error adding is_location column to ${tableName} table`,
+                e,
+              ),
+            );
+        }
+      });
     }
   });
   return db;

--- a/server/models/posts.model.ts
+++ b/server/models/posts.model.ts
@@ -10,11 +10,27 @@ export default function (app: Application): Knex {
         .createTable(tableName, (table) => {
           table.increments('id');
           table.string('body');
+          table.string('weather').nullable();
           table.datetime('date');
           table.integer('user_id');
         })
         .then(() => console.log(`Created ${tableName} table`))
         .catch((e) => console.error(`Error creating ${tableName} table`, e));
+    } else {
+      db.schema.hasColumn(tableName, 'weather').then((hasWeather) => {
+        if (!hasWeather) {
+          db.schema
+            .table(tableName, (table) => {
+              table.string('weather').nullable();
+            })
+            .catch((e) =>
+              console.error(
+                `Error adding weather column to ${tableName} table`,
+                e,
+              ),
+            );
+        }
+      });
     }
   });
   // Labels   []Label   `gorm:"many2many:posts_labels";"ForeignKey:PostId"`

--- a/src/Days/PostShow/PostPhotos/index.tsx
+++ b/src/Days/PostShow/PostPhotos/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { ReactNode, useContext } from 'react';
 import Button from '@mui/material/Button';
 import { Dialog, Grid, Typography, Box } from '@mui/material';
 import GPhotosContext from '../../../shared/context/GPhotosContext';
@@ -7,9 +7,15 @@ import { PhotoType } from '../../../shared/types';
 
 type Props = {
   date: number | string;
+  hideGetPhotosButton?: boolean;
+  extraAction?: ReactNode;
 };
 
-const PostPhotos = ({ date }: Props) => {
+const PostPhotos = ({
+  date,
+  hideGetPhotosButton = false,
+  extraAction,
+}: Props) => {
   const [photos, setPhotos] = React.useState<PhotoType[]>([]);
   const [isFetched, setFetched] = React.useState(false);
   const [showImg, setShowImg] = React.useState('');
@@ -48,7 +54,10 @@ const PostPhotos = ({ date }: Props) => {
         margin: (theme) => theme.spacing(1),
       }}
     >
-      {isFetched ? null : <Button onClick={getPhotos}>GET PHOTOS</Button>}
+      {!isFetched && !hideGetPhotosButton ? (
+        <Button onClick={getPhotos}>GET PHOTOS</Button>
+      ) : null}
+      {extraAction ? <Box>{extraAction}</Box> : null}
       {isFetched && !photos.length ? (
         <Typography>No photos found...</Typography>
       ) : null}

--- a/src/Days/PostShow/index.tsx
+++ b/src/Days/PostShow/index.tsx
@@ -432,22 +432,6 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
             >
               x
             </Button>
-            <Button
-              onClick={handleFetchWeather}
-              color="inherit"
-              sx={{
-                textTransform: 'lowercase',
-                padding: (theme) => theme.spacing(0, 1),
-                minWidth: 40,
-              }}
-              disabled={
-                post.id === 0 ||
-                editPostMutation.isLoading ||
-                weatherMutation.isLoading
-              }
-            >
-              wthr
-            </Button>
           </Grid>
         </Grid>
 
@@ -574,7 +558,28 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
                 ))}
               </Grid>
             ) : null}
-            <PostPhotos date={post.date} />
+            <PostPhotos
+              date={post.date}
+              hideGetPhotosButton
+              extraAction={
+                <Button
+                  onClick={handleFetchWeather}
+                  color="inherit"
+                  sx={{
+                    textTransform: 'lowercase',
+                    padding: (theme) => theme.spacing(0, 1),
+                    minWidth: 40,
+                  }}
+                  disabled={
+                    post.id === 0 ||
+                    editPostMutation.isLoading ||
+                    weatherMutation.isLoading
+                  }
+                >
+                  wthr
+                </Button>
+              }
+            />
             {post.comments.map((comment) => (
               <PostComment key={comment.id} comment={comment} />
             ))}

--- a/src/Days/PostShow/index.tsx
+++ b/src/Days/PostShow/index.tsx
@@ -25,6 +25,7 @@ import {
   addLabelToPost,
   deleteContextSegment,
   getContextSegments,
+  getHistoricalWeather,
   patchContextSegment,
   deleteLabelFromPost,
   deletePost,
@@ -33,7 +34,12 @@ import {
 } from '../../shared/api/routes';
 import { useUpdateMutation } from '../../shared/hooks/useUpdateMutation';
 import { useDeleteMutation } from '../../shared/hooks/useDeleteMutation';
-import { ContextSegmentType, LabelType, PostType } from '../../shared/types';
+import {
+  ContextSegmentType,
+  LabelType,
+  PeriodType,
+  PostType,
+} from '../../shared/types';
 import { dateToMySQLFormat } from '../../shared/utils/mappers';
 import PostEdit from './PostEdit';
 import PostComment from './PostComment';
@@ -51,6 +57,52 @@ type Props = {
 };
 
 const toDateOnly = (value: string | Date) => dayjs(value).format('YYYY-MM-DD');
+
+const weatherCodeToLabel = (code?: number) => {
+  if (code == null) return 'Unknown';
+  if (code === 0) return 'Clear';
+  if ([1, 2].includes(code)) return 'Partly cloudy';
+  if (code === 3) return 'Overcast';
+  if ([45, 48].includes(code)) return 'Fog';
+  if ([51, 53, 55, 56, 57].includes(code)) return 'Drizzle';
+  if ([61, 63, 65, 66, 67].includes(code)) return 'Rain';
+  if ([71, 73, 75, 77].includes(code)) return 'Snow';
+  if ([80, 81, 82].includes(code)) return 'Rain showers';
+  if ([85, 86].includes(code)) return 'Snow showers';
+  if (code === 95) return 'Thunderstorm';
+  if ([96, 99].includes(code)) return 'Thunderstorm + hail';
+  return `WMO ${code}`;
+};
+
+const parseLocationDetails = (details?: string | null) => {
+  if (!details) {
+    return null;
+  }
+  const [latRaw, lonRaw] = details.split(',').map((val) => val.trim());
+  const latitude = Number(latRaw);
+  const longitude = Number(lonRaw);
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+    return null;
+  }
+  return { latitude, longitude };
+};
+
+const getPeriodDurationDays = (period: PeriodType) => {
+  if (!period.start || !period.end) {
+    return Number.POSITIVE_INFINITY;
+  }
+  const start = dayjs(period.start);
+  const end = dayjs(period.end);
+  if (!start.isValid() || !end.isValid()) {
+    return Number.POSITIVE_INFINITY;
+  }
+  return Math.max(end.diff(start, 'day'), 0);
+};
+
+const toOneDecimal = (value: unknown) => {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric.toFixed(1) : '?';
+};
 
 const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
   const queryClient = useQueryClient();
@@ -104,6 +156,17 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
       date: dateToMySQLFormat(updateDate),
     }),
     () => setIsEdit(false),
+  );
+  const weatherMutation = useUpdateMutation(
+    (weather: string) =>
+      editPost(post.id, {
+        body: post.body,
+        date: dateToMySQLFormat(postDate),
+        weather,
+      }),
+    invalidateQueries,
+    post.id,
+    (weather: string) => ({ weather }),
   );
   const refreshContextData = () => {
     queryClient.invalidateQueries(invalidateQueries);
@@ -214,6 +277,36 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
       return;
     }
     deleteContextMutation.mutate(selectedContext.id);
+  };
+  const handleFetchWeather = async () => {
+    const locationPeriods = (post.periods || [])
+      .filter((period) => period.is_location)
+      .filter((period) => parseLocationDetails(period.location_details));
+    if (!locationPeriods.length) {
+      return;
+    }
+    const shortestLocation = locationPeriods.reduce((shortest, current) => {
+      return getPeriodDurationDays(current) < getPeriodDurationDays(shortest)
+        ? current
+        : shortest;
+    });
+    const location = parseLocationDetails(shortestLocation.location_details);
+    if (!location) {
+      return;
+    }
+    const weatherData = await getHistoricalWeather({
+      latitude: location.latitude,
+      longitude: location.longitude,
+      date: postDate,
+    });
+    const code = weatherData?.daily?.weather_code?.[0];
+    const tMax = weatherData?.daily?.temperature_2m_max?.[0];
+    const tMin = weatherData?.daily?.temperature_2m_min?.[0];
+    const precipitation = weatherData?.daily?.precipitation_sum?.[0];
+    const summary = `${weatherCodeToLabel(code)} ${toOneDecimal(
+      tMax,
+    )}/${toOneDecimal(tMin)}C, rain ${toOneDecimal(precipitation)}mm`;
+    weatherMutation.mutate(summary);
   };
 
   const getHighlightedText = (text: string, highlight: string) => {
@@ -339,6 +432,22 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
             >
               x
             </Button>
+            <Button
+              onClick={handleFetchWeather}
+              color="inherit"
+              sx={{
+                textTransform: 'lowercase',
+                padding: (theme) => theme.spacing(0, 1),
+                minWidth: 40,
+              }}
+              disabled={
+                post.id === 0 ||
+                editPostMutation.isLoading ||
+                weatherMutation.isLoading
+              }
+            >
+              wthr
+            </Button>
           </Grid>
         </Grid>
 
@@ -430,6 +539,17 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
                     />
                   </Grid>
                 ))}
+              </Grid>
+            ) : null}
+            {post.weather ? (
+              <Grid container sx={{ marginTop: 1 }}>
+                <Chip
+                  label={post.weather}
+                  variant="outlined"
+                  sx={{
+                    color: (theme) => theme.palette.secondary.main,
+                  }}
+                />
               </Grid>
             ) : null}
             {contextSegments.length > 0 ? (

--- a/src/Days/Settings/PeriodSettings/index.tsx
+++ b/src/Days/Settings/PeriodSettings/index.tsx
@@ -17,62 +17,6 @@ import { useCreateMutation } from '../../../shared/hooks/useCreateMutation';
 import { PeriodType } from '../../../shared/types';
 import { dateToMySQLFormat } from '../../../shared/utils/mappers';
 
-const geoAliases: Record<string, string> = {
-  варшава: 'warsaw',
-  польша: 'poland',
-  польща: 'poland',
-  киев: 'kyiv',
-  київ: 'kyiv',
-  афины: 'athens',
-  афіни: 'athens',
-};
-
-const normalizeGeoText = (value: string) =>
-  value
-    .trim()
-    .replace(/[,_-]+/g, ' ')
-    .replace(/\s+/g, ' ');
-
-const applyAliases = (value: string) =>
-  value
-    .split(' ')
-    .map((w) => geoAliases[w.toLowerCase()] || w)
-    .join(' ');
-
-const buildGeocodeQueries = (rawName: string): string[] => {
-  const base = normalizeGeoText(rawName);
-  const queries = new Set<string>([base]);
-  const bracketMatch = base.match(/^(.+?)\s*\(([^)]+)\)\s*$/);
-
-  if (bracketMatch) {
-    const city = normalizeGeoText(bracketMatch[1]);
-    const country = normalizeGeoText(bracketMatch[2]);
-    queries.add(city);
-    queries.add(country ? `${city}, ${country}` : city);
-    queries.add(country ? `${city} ${country}` : city);
-  } else {
-    const noBrackets = normalizeGeoText(base.replace(/[()]/g, ' '));
-    queries.add(noBrackets);
-  }
-
-  for (const query of [...queries]) {
-    queries.add(applyAliases(query));
-  }
-
-  return [...queries].filter(Boolean);
-};
-
-const resolveLocation = async (name: string) => {
-  const queries = buildGeocodeQueries(name);
-  for (const query of queries) {
-    const result = await geocodeLocation(query);
-    if (result?.latitude != null && result?.longitude != null) {
-      return result;
-    }
-  }
-  return null;
-};
-
 const PeriodSettings = () => {
   const [isAdd, setIsAdd] = React.useState(false);
   const [isOpen, setIsOpen] = React.useState(false);
@@ -107,8 +51,8 @@ const PeriodSettings = () => {
     setIsPopulating(true);
     try {
       for (const period of targets) {
-        const geocode = await resolveLocation(period.name);
-        if (geocode?.latitude == null || geocode?.longitude == null) {
+        const geocode = await geocodeLocation(period.name);
+        if (!geocode?.latitude || !geocode?.longitude) {
           continue;
         }
         await putPeriod(period.id, {

--- a/src/Days/Settings/PeriodSettings/index.tsx
+++ b/src/Days/Settings/PeriodSettings/index.tsx
@@ -17,6 +17,62 @@ import { useCreateMutation } from '../../../shared/hooks/useCreateMutation';
 import { PeriodType } from '../../../shared/types';
 import { dateToMySQLFormat } from '../../../shared/utils/mappers';
 
+const geoAliases: Record<string, string> = {
+  варшава: 'warsaw',
+  польша: 'poland',
+  польща: 'poland',
+  киев: 'kyiv',
+  київ: 'kyiv',
+  афины: 'athens',
+  афіни: 'athens',
+};
+
+const normalizeGeoText = (value: string) =>
+  value
+    .trim()
+    .replace(/[,_-]+/g, ' ')
+    .replace(/\s+/g, ' ');
+
+const applyAliases = (value: string) =>
+  value
+    .split(' ')
+    .map((w) => geoAliases[w.toLowerCase()] || w)
+    .join(' ');
+
+const buildGeocodeQueries = (rawName: string): string[] => {
+  const base = normalizeGeoText(rawName);
+  const queries = new Set<string>([base]);
+  const bracketMatch = base.match(/^(.+?)\s*\(([^)]+)\)\s*$/);
+
+  if (bracketMatch) {
+    const city = normalizeGeoText(bracketMatch[1]);
+    const country = normalizeGeoText(bracketMatch[2]);
+    queries.add(city);
+    queries.add(country ? `${city}, ${country}` : city);
+    queries.add(country ? `${city} ${country}` : city);
+  } else {
+    const noBrackets = normalizeGeoText(base.replace(/[()]/g, ' '));
+    queries.add(noBrackets);
+  }
+
+  for (const query of [...queries]) {
+    queries.add(applyAliases(query));
+  }
+
+  return [...queries].filter(Boolean);
+};
+
+const resolveLocation = async (name: string) => {
+  const queries = buildGeocodeQueries(name);
+  for (const query of queries) {
+    const result = await geocodeLocation(query);
+    if (result?.latitude != null && result?.longitude != null) {
+      return result;
+    }
+  }
+  return null;
+};
+
 const PeriodSettings = () => {
   const [isAdd, setIsAdd] = React.useState(false);
   const [isOpen, setIsOpen] = React.useState(false);
@@ -51,8 +107,8 @@ const PeriodSettings = () => {
     setIsPopulating(true);
     try {
       for (const period of targets) {
-        const geocode = await geocodeLocation(period.name);
-        if (!geocode?.latitude || !geocode?.longitude) {
+        const geocode = await resolveLocation(period.name);
+        if (geocode?.latitude == null || geocode?.longitude == null) {
           continue;
         }
         await putPeriod(period.id, {

--- a/src/Days/Settings/PeriodSettings/index.tsx
+++ b/src/Days/Settings/PeriodSettings/index.tsx
@@ -3,10 +3,12 @@ import { Button, Collapse, Grid, IconButton, Typography } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import ExpandLess from '@mui/icons-material/ExpandLess';
 import ExpandMore from '@mui/icons-material/ExpandMore';
+import SyncIcon from '@mui/icons-material/Sync';
 import { useQuery } from '@tanstack/react-query';
 import EditableTable from '../../../shared/components/EditableTable';
 import {
   deletePeriod,
+  geocodeLocation,
   getPeriods,
   postPeriod,
   putPeriod,
@@ -18,6 +20,7 @@ import { dateToMySQLFormat } from '../../../shared/utils/mappers';
 const PeriodSettings = () => {
   const [isAdd, setIsAdd] = React.useState(false);
   const [isOpen, setIsOpen] = React.useState(false);
+  const [isPopulating, setIsPopulating] = React.useState(false);
   const periodsData = useQuery(['periods'], getPeriods, { initialData: [] });
   const createMutation = useCreateMutation(
     (vals: PeriodType) => postPeriod(vals),
@@ -32,8 +35,40 @@ const PeriodSettings = () => {
       start: dateToMySQLFormat(values.start),
       name: values.name,
       is_location: !!values.is_location,
+      location_details: values.location_details || null,
     };
     createMutation.mutate(data);
+  };
+
+  const handlePopulateLocationDetails = async () => {
+    const periods = (periodsData.data || []) as PeriodType[];
+    const targets = periods.filter(
+      (period) => period.is_location && !period.location_details,
+    );
+    if (!targets.length) {
+      return;
+    }
+    setIsPopulating(true);
+    try {
+      for (const period of targets) {
+        const geocode = await geocodeLocation(period.name);
+        if (!geocode?.latitude || !geocode?.longitude) {
+          continue;
+        }
+        await putPeriod(period.id, {
+          name: period.name,
+          start: dateToMySQLFormat(period.start),
+          end: period.end ? dateToMySQLFormat(period.end) : null,
+          is_location: !!period.is_location,
+          location_details: `${Number(geocode.latitude).toFixed(5)},${Number(
+            geocode.longitude,
+          ).toFixed(5)}`,
+        });
+      }
+    } finally {
+      setIsPopulating(false);
+      periodsData.refetch();
+    }
   };
 
   return (
@@ -69,6 +104,12 @@ const PeriodSettings = () => {
                 type: 'boolean',
                 render: (row) => (row.is_location ? 'Yes' : 'No'),
               },
+              {
+                name: 'location_details',
+                label: 'Lat,Lon',
+                type: 'string',
+                render: (row) => row.location_details || '',
+              },
             ]}
             isAdd={isAdd}
             cancelAdd={() => setIsAdd(false)}
@@ -79,6 +120,7 @@ const PeriodSettings = () => {
                 start: dateToMySQLFormat(data.start),
                 name: data.name,
                 is_location: !!data.is_location,
+                location_details: data.location_details || null,
               };
               return putPeriod(id, values);
             }}
@@ -88,6 +130,13 @@ const PeriodSettings = () => {
           />
           <IconButton onClick={() => setIsAdd(true)}>
             <AddIcon />
+          </IconButton>
+          <IconButton
+            onClick={handlePopulateLocationDetails}
+            disabled={isPopulating}
+            title="Populate lat/lon for location periods"
+          >
+            <SyncIcon />
           </IconButton>
         </Collapse>
       </Grid>

--- a/src/Days/Settings/PeriodSettings/index.tsx
+++ b/src/Days/Settings/PeriodSettings/index.tsx
@@ -31,6 +31,7 @@ const PeriodSettings = () => {
       end: values.isendInProgress ? null : dateToMySQLFormat(values.end),
       start: dateToMySQLFormat(values.start),
       name: values.name,
+      is_location: !!values.is_location,
     };
     createMutation.mutate(data);
   };
@@ -62,6 +63,12 @@ const PeriodSettings = () => {
                 type: 'nullable-date',
                 render: (row) => (row.end ? row.end.slice(0, 10) : ''),
               },
+              {
+                name: 'is_location',
+                label: 'Location period',
+                type: 'boolean',
+                render: (row) => (row.is_location ? 'Yes' : 'No'),
+              },
             ]}
             isAdd={isAdd}
             cancelAdd={() => setIsAdd(false)}
@@ -71,6 +78,7 @@ const PeriodSettings = () => {
                 end: data.isendInProgress ? null : dateToMySQLFormat(data.end),
                 start: dateToMySQLFormat(data.start),
                 name: data.name,
+                is_location: !!data.is_location,
               };
               return putPeriod(id, values);
             }}

--- a/src/Days/Settings/PeriodSettings/index.tsx
+++ b/src/Days/Settings/PeriodSettings/index.tsx
@@ -17,6 +17,11 @@ import { useCreateMutation } from '../../../shared/hooks/useCreateMutation';
 import { PeriodType } from '../../../shared/types';
 import { dateToMySQLFormat } from '../../../shared/utils/mappers';
 
+const getFirstWord = (value: string) => {
+  const [firstWord] = value.trim().split(/\s+/);
+  return firstWord || value.trim();
+};
+
 const PeriodSettings = () => {
   const [isAdd, setIsAdd] = React.useState(false);
   const [isOpen, setIsOpen] = React.useState(false);
@@ -51,8 +56,9 @@ const PeriodSettings = () => {
     setIsPopulating(true);
     try {
       for (const period of targets) {
-        const geocode = await geocodeLocation(period.name);
-        if (!geocode?.latitude || !geocode?.longitude) {
+        const geocodeQuery = getFirstWord(period.name);
+        const geocode = await geocodeLocation(geocodeQuery);
+        if (geocode?.latitude == null || geocode?.longitude == null) {
           continue;
         }
         await putPeriod(period.id, {

--- a/src/shared/api/routes.ts
+++ b/src/shared/api/routes.ts
@@ -270,6 +270,27 @@ export const geocodeLocation = (name: string) =>
     },
   }).then((resp) => resp.data?.results?.[0] || null);
 
+export const getHistoricalWeather = ({
+  latitude,
+  longitude,
+  date,
+}: {
+  latitude: number;
+  longitude: number;
+  date: string;
+}) =>
+  apiGetRequest(`https://archive-api.open-meteo.com/v1/archive`, {
+    params: {
+      latitude,
+      longitude,
+      start_date: date,
+      end_date: date,
+      daily:
+        'weather_code,temperature_2m_max,temperature_2m_min,precipitation_sum',
+      timezone: 'auto',
+    },
+  }).then((resp) => resp.data);
+
 export const getUser = () =>
   apiLocalGetRequest(`users/me`).then((resp) => resp.data);
 export const editUser = (data: any) =>

--- a/src/shared/api/routes.ts
+++ b/src/shared/api/routes.ts
@@ -260,6 +260,16 @@ export const deletePeriod = (id: number) =>
 export const putPeriod = (id: number, data: any) =>
   apiLocalPutRequest(`periods/${id}`, data).then((resp) => resp.data);
 
+export const geocodeLocation = (name: string) =>
+  apiGetRequest(`https://geocoding-api.open-meteo.com/v1/search`, {
+    params: {
+      name,
+      count: 1,
+      language: 'en',
+      format: 'json',
+    },
+  }).then((resp) => resp.data?.results?.[0] || null);
+
 export const getUser = () =>
   apiLocalGetRequest(`users/me`).then((resp) => resp.data);
 export const editUser = (data: any) =>

--- a/src/shared/components/EditableTable/EditRow/index.tsx
+++ b/src/shared/components/EditableTable/EditRow/index.tsx
@@ -36,6 +36,8 @@ const getInitialValues = (columns: ColumnType[], item: TableItemType) => {
       initialValues[col.name] =
         (col as SelectColumnType).options.find((o) => o.name === item[col.name])
           ?.id || item[col.name];
+    } else if (col.type === 'boolean') {
+      initialValues[col.name] = !!item[col.name];
     } else {
       initialValues[col.name] = item[col.name] || '';
     }
@@ -126,6 +128,25 @@ const PeriodEditRow = ({ item, onSubmit, onCancel, columns }: Props) => {
                     ))}
                   </Select>
                 </FormControl>
+              </TableCell>
+            );
+          case 'boolean':
+            return (
+              <TableCell key={`edit-${col.name}`}>
+                <FormControlLabel
+                  control={
+                    <Checkbox
+                      checked={!!values[col.name]}
+                      onChange={() =>
+                        setValues({
+                          ...values,
+                          [col.name]: !values[col.name],
+                        })
+                      }
+                    />
+                  }
+                  label={col.label}
+                />
               </TableCell>
             );
           default:

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -17,6 +17,7 @@ export type PhotoType = {
 export type PostType = {
   id: number;
   date: string;
+  weather?: string | null;
   labels: number[];
   comments: CommentType[];
   body: string;

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -3,6 +3,7 @@ export type PeriodType = {
   name: string;
   start: string;
   end: string;
+  is_location?: boolean;
   isendInProgress: boolean;
 };
 

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -4,6 +4,7 @@ export type PeriodType = {
   start: string;
   end: string;
   is_location?: boolean;
+  location_details?: string | null;
   isendInProgress: boolean;
 };
 

--- a/src/shared/types/table.tsx
+++ b/src/shared/types/table.tsx
@@ -13,7 +13,13 @@ export type ColumnType =
   | {
       name: string;
       label: string;
-      type: 'date' | 'nullable-date' | 'select' | 'string' | 'number';
+      type:
+        | 'date'
+        | 'nullable-date'
+        | 'select'
+        | 'string'
+        | 'number'
+        | 'boolean';
       render?: (item: TableItemType, col: ColumnType) => ReactElement | string;
     };
 


### PR DESCRIPTION
## What Changed
- Added a new `weather` field on posts (DB + shared FE types) to persist weather summaries per entry.
- Added location metadata support on periods:
  - `is_location` boolean flag
  - `location_details` string (`lat,lon`)
- Extended Period Settings UI:
  - manage `is_location`
  - show/edit `location_details`
  - bulk geocode location periods and populate coordinates
- Added on-demand historical weather fetch for posts (Open-Meteo archive API):
  - chooses location periods attached to the post date
  - if multiple location periods match, picks the shortest period
  - stores a weather summary back into `post.weather`
- Updated post UI behavior:
  - moved weather action near the photos area
  - temporarily hid `GET PHOTOS` button
- Included context-segment improvements present in this branch:
  - context-segments service/model wiring
  - context chips/edit/split/delete flows in post create/show/history retrieval

## Why
The goal was to support weather per diary post without forcing users to manually enter weather each time. The implemented approach lets users define location periods once, auto-fill coordinates, and then fetch historical weather on demand for a post date. This keeps daily posting lightweight while still allowing corrections for ambiguous locations.

## Important Implementation Details
- Period-based location source:
  - weather lookup depends on periods marked as `is_location=true`
  - coordinates are read from `location_details` in `lat,lon` format
- Geocoding/backfill:
  - bulk population currently geocodes using the first word of period name (intentional simplification); remaining edge cases can be corrected manually
- Weather selection logic:
  - among matching location periods for a post, shortest duration wins
  - weather summary stores condition + min/max temp + precipitation
- Data model updates are backward-compatible:
  - added columns are nullable/defaulted and auto-added for existing tables

This PR was written using [Vibe Kanban](https://vibekanban.com)
