### PR TITLE
Fix weather fetch invalidation and improve weather button UX (Vibe Kanban)

### DIFF
--- a/src/Days/PostShow/index.tsx
+++ b/src/Days/PostShow/index.tsx
@@ -116,8 +116,12 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
   const [startDate, setStartDate] = React.useState('');
   const [endDate, setEndDate] = React.useState('');
   const [splitDate, setSplitDate] = React.useState('');
+  const [weather, setWeather] = React.useState(post.weather || '');
   const postDate = toDateOnly(post.date);
   const [updateDate, setUpdateDate] = React.useState(postDate);
+  React.useEffect(() => {
+    setWeather(post.weather || '');
+  }, [post.weather]);
   const contextByDate = useQuery({
     queryKey: ['context_segments', postDate],
     queryFn: () => getContextSegments({ date: postDate }),
@@ -155,16 +159,21 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
     }),
     () => setIsEdit(false),
   );
-  const weatherMutation = useUpdateMutation(
-    (weather: string) =>
+  const weatherMutation = useMutation(
+    (weatherLabel: string) =>
       editPost(post.id, {
         body: post.body,
         date: dateToMySQLFormat(postDate),
-        weather,
+        weather: weatherLabel,
       }),
-    invalidateQueries,
-    post.id,
-    (weather: string) => ({ weather }),
+    {
+      onSuccess: (_, weatherLabel) => {
+        setWeather(weatherLabel);
+        if (invalidateQueries.length > 0) {
+          queryClient.invalidateQueries({ queryKey: invalidateQueries });
+        }
+      },
+    },
   );
   const refreshContextData = () => {
     queryClient.invalidateQueries({ queryKey: invalidateQueries });
@@ -332,10 +341,10 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
   )
     ? post.context_segments
     : Array.isArray(contextByDate.data)
-      ? (contextByDate.data as ContextSegmentType[])
-      : Array.isArray((contextByDate.data as any)?.data)
-        ? ((contextByDate.data as any).data as ContextSegmentType[])
-        : [];
+    ? (contextByDate.data as ContextSegmentType[])
+    : Array.isArray((contextByDate.data as any)?.data)
+    ? ((contextByDate.data as any).data as ContextSegmentType[])
+    : [];
 
   return (
     <Box
@@ -518,10 +527,10 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
                 ))}
               </Grid>
             ) : null}
-            {post.weather ? (
+            {weather ? (
               <Grid container sx={{ marginTop: 1 }}>
                 <Chip
-                  label={post.weather}
+                  label={weather}
                   variant="outlined"
                   sx={{
                     color: (theme) => theme.palette.secondary.main,
@@ -556,12 +565,25 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
               hideGetPhotosButton
               extraAction={
                 <Button
+                  type="button"
                   onClick={handleFetchWeather}
-                  color="inherit"
+                  variant="outlined"
+                  size="small"
                   sx={{
-                    textTransform: 'lowercase',
-                    padding: (theme) => theme.spacing(0, 1),
-                    minWidth: 40,
+                    textTransform: 'none',
+                    borderRadius: 999,
+                    fontSize: 12,
+                    fontWeight: 600,
+                    lineHeight: 1.2,
+                    padding: (theme) => theme.spacing(0.5, 1.25),
+                    minWidth: 96,
+                    borderColor: (theme) => theme.palette.secondary.main,
+                    color: (theme) => theme.palette.secondary.main,
+                    '&:hover': {
+                      borderColor: (theme) => theme.palette.secondary.dark,
+                      backgroundColor: (theme) =>
+                        theme.palette.secondary.light + '22',
+                    },
                   }}
                   disabled={
                     post.id === 0 ||
@@ -569,7 +591,7 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
                     weatherMutation.isPending
                   }
                 >
-                  wthr
+                  {weatherMutation.isPending ? 'Loading...' : 'Get weather'}
                 </Button>
               }
             />


### PR DESCRIPTION
## Summary
This PR fixes the weather action in post details so it no longer triggers broad query refetches, and improves the weather button UI for better clarity and consistency.

## What Changed
- Updated weather updates in `src/Days/PostShow/index.tsx` to use a dedicated `useMutation` flow instead of the generic `useUpdateMutation` path.
- Added guarded invalidation so post-list queries are only invalidated when `invalidateQueries` is non-empty.
- Added local `weather` state synchronized from `post.weather` via `useEffect` so the weather chip updates immediately after a successful fetch.
- Updated weather chip rendering to read from local state.
- Restyled the weather action button:
  - explicit `type="button"`
  - `outlined` / `size="small"`
  - pill radius, improved spacing, stronger text weight
  - clearer label (`Get weather`) and loading state (`Loading...`)

## Why
The task reported that clicking the weather button was causing the page to reload/refetch all queries instead of only handling weather. In this codebase, one caller passes `invalidateQueries={[]}` (search view), and invalidating with an empty key can behave as a broad invalidation. This change ensures weather updates are scoped and avoids unnecessary global query refreshes, while also improving the visual quality and usability of the button.

## Important Implementation Details
- Weather updates now call `editPost` and on success:
  - update local `weather` state immediately
  - invalidate only when `invalidateQueries.length > 0`
- Existing behavior for normal list pages is preserved because non-empty query keys still invalidate as expected.
- This PR is intentionally scoped to `PostShow` weather interaction; no API contracts were changed.

This PR was written using [Vibe Kanban](https://vibekanban.com)
