### PR TITLE
Fix GitHub Actions pnpm version conflict in CI (Vibe Kanban)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: pnpm/action-setup@v4
-      with:
-        version: 10
     - name: Use Node.js 20.x
       uses: actions/setup-node@v4
       with:


### PR DESCRIPTION
## What changes were made
- Updated GitHub Actions workflow in `.github/workflows/node.js.yml`.
- Removed the explicit `version: 10` from `pnpm/action-setup@v4`.
- Left `packageManager: pnpm@10.12.4` in `package.json` as the single pnpm version source.

## Why these changes were made
CI was failing in the `pnpm/action-setup` step because pnpm version was defined in two places:
- workflow input (`version: 10`), and
- `package.json` (`packageManager: pnpm@10.12.4`).

The action rejects this configuration to prevent version mismatch issues, so the workflow needed to be aligned.

## Important implementation details
- This PR is intentionally minimal and changes only one workflow file.
- The fix resolves the exact runtime error: "Multiple versions of pnpm specified".
- Using `packageManager` as the source of truth keeps local/dev and CI pnpm versions consistent.

This PR was written using [Vibe Kanban](https://vibekanban.com)
