### PR TITLE
Fix post creation payload to prevent empty body submissions (Vibe Kanban)

### DIFF
--- a/src/Days/PostList/PostCreate/index.tsx
+++ b/src/Days/PostList/PostCreate/index.tsx
@@ -15,15 +15,19 @@ const createPost = (body: string, date: string) => ({
   body,
   date: dateToMySQLFormat(date),
 });
+type NewPostPayload = {
+  body: string;
+  date: string;
+};
 
 const PostCreate = () => {
   const [value, setValue] = React.useState('');
   const [date, setDate] = React.useState(today);
   const createPostMutation = useCreateMutation(
-    () => postPost(createPost(value, date)),
+    (payload: NewPostPayload) => postPost(createPost(payload.body, payload.date)),
     ['recent_posts'],
-    (old: any[]) => [
-      { ...createPost(value, date), id: 0, labels: [], comments: [] },
+    (old: any[], payload: NewPostPayload) => [
+      { ...createPost(payload.body, payload.date), id: 0, labels: [], comments: [] },
       ...old,
     ],
     () => {
@@ -41,7 +45,7 @@ const PostCreate = () => {
 
   const handleSubmit = () => {
     if (value) {
-      createPostMutation.mutate(value);
+      createPostMutation.mutate({ body: value, date });
     }
   };
 


### PR DESCRIPTION
## Summary
- Fixed post creation flow to send the request payload from mutation variables instead of component state closures.
- Updated PostCreate mutation wiring in src/Days/PostList/PostCreate/index.tsx to pass { body, date } through mutate(...).
- Added a typed payload (NewPostPayload) and reused it in both the mutation function and optimistic cache updater.

## Why
The task context reported that creating a post was sending an empty body. The previous implementation captured value/date from component state inside the mutation callback while also clearing input state in the mutation lifecycle. This made it possible for the API call to use cleared state and submit an empty body.

## Implementation Details
- Changed mutation function from a closure-based call:
  - () => postPost(createPost(value, date))
  to a payload-driven call:
  - (payload) => postPost(createPost(payload.body, payload.date))
- Changed optimistic updater to use the same mutation payload instead of reading from local state.
- Changed submit handler to call:
  - createPostMutation.mutate({ body: value, date })
- This keeps API and optimistic data paths consistent and eliminates timing/state-race issues around input reset.

This PR was written using [Vibe Kanban](https://vibekanban.com)