### PR TITLE
Fix post creation payload race causing empty text (Vibe Kanban)

### DIFF
--- a/src/Days/PostList/PostCreate/index.tsx
+++ b/src/Days/PostList/PostCreate/index.tsx
@@ -129,11 +129,11 @@ const PostCreate = () => {
     },
   });
   const createPostMutation = useCreateMutation(
-    () => postPost(createPost(value, date)),
+    (payload: { body: string; date: string }) => postPost(payload),
     ['recent_posts'],
-    (old: any[]) => [
+    (old: any[] = [], payload: { body: string; date: string }) => [
       {
-        ...createPost(value, date),
+        ...payload,
         id: 0,
         labels: [],
         comments: [],
@@ -157,7 +157,7 @@ const PostCreate = () => {
 
   const handleSubmit = () => {
     if (value) {
-      createPostMutation.mutate(value);
+      createPostMutation.mutate(createPost(value, date));
     }
   };
   const isValidDateRange = !endDate || endDate >= startDate;


### PR DESCRIPTION
## Summary
This PR fixes a regression where newly created posts could be saved with an empty `body` value.

## What Changed
- Updated post creation in `src/Days/PostList/PostCreate/index.tsx` to pass a full payload object (`{ body, date }`) into `createPostMutation.mutate(...)`.
- Changed `useCreateMutation` usage for post creation so the mutation function now accepts and sends the explicit payload (`postPost(payload)`) instead of reading `value`/`date` from component state.
- Updated the optimistic cache updater to use the same mutation payload and added a safe default for previous cache state (`old: any[] = []`).

## Why These Changes Were Made
The task context reports that after recent changes, new posts were being created with empty text. The root issue is a timing/race interaction with optimistic updates: the input clear callback can run during mutation lifecycle, while the request function previously read from live component state. If state was cleared first, the API request could submit an empty `body`.

## Important Implementation Details
- Payload is now created at submit time via `createPost(value, date)` and passed through the entire mutation flow.
- Both the API call and optimistic UI entry rely on that immutable payload, removing dependence on mutable React state during async mutation execution.
- This keeps optimistic behavior intact while ensuring request correctness.

This PR was written using [Vibe Kanban](https://vibekanban.com)
