### PR TITLE
Replace Google Photos with S3 media service, presigned upload/read flow, and rollout docs (Vibe Kanban)

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -49,9 +49,10 @@
     "connection": "mysql://vova:vova@localhost:3310/pa2023"
   },
   "media": {
-    "bucket": "pa2023-media",
+    "bucket": "pa2026-662203418679-us-east-1-an",
     "region": "us-east-1",
     "prefix": "media/",
+    "uploadStorageClass": "GLACIER_IR",
     "getUrlTtlSeconds": 300,
     "putUrlTtlSeconds": 900
   }

--- a/config/default.json
+++ b/config/default.json
@@ -47,5 +47,12 @@
   "mysql": {
     "client": "mysql2",
     "connection": "mysql://vova:vova@localhost:3310/pa2023"
+  },
+  "media": {
+    "bucket": "pa2023-media",
+    "region": "us-east-1",
+    "prefix": "media/",
+    "getUrlTtlSeconds": 300,
+    "putUrlTtlSeconds": 900
   }
 }

--- a/docs/s3-media-rollout.md
+++ b/docs/s3-media-rollout.md
@@ -24,6 +24,7 @@ Example:
 - `media.bucket`
 - `media.region`
 - `media.prefix`
+- `media.uploadStorageClass` (set to `GLACIER_IR` if you want to skip Standard)
 - `media.getUrlTtlSeconds`
 - `media.putUrlTtlSeconds`
 

--- a/docs/s3-media-rollout.md
+++ b/docs/s3-media-rollout.md
@@ -1,0 +1,102 @@
+# S3 Media Rollout (Shared Bucket, No DB)
+
+## What is implemented
+
+- New authenticated backend service: `GET /media` and `POST /media`
+- `GET /media` lists media from S3 and returns presigned read URLs
+- `POST /media` with `{ "action": "init-upload", ... }` returns presigned upload URL
+- Existing UI photo views now read from `/media` instead of Google Photos API
+
+## Key format
+
+Objects are expected under:
+
+`media/mmdd=MM-DD/owner=<userId>/ts=<ISO8601>_<uuid>.<ext>`
+
+Example:
+
+`media/mmdd=04-04/owner=1/ts=2024-04-04T19:13:00Z_9d9e...jpg`
+
+## Backend config
+
+`config/default.json` now includes:
+
+- `media.bucket`
+- `media.region`
+- `media.prefix`
+- `media.getUrlTtlSeconds`
+- `media.putUrlTtlSeconds`
+
+For production, set:
+
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_REGION` (if different from config)
+
+Optional for S3-compatible storage:
+
+- `AWS_S3_ENDPOINT`
+- `AWS_S3_FORCE_PATH_STYLE=true`
+
+## API contract
+
+### List media
+
+`GET /media?date=<iso>&pageSize=24&pageToken=<token>`
+
+Optional:
+
+- `mmdd=04-04`
+- `owner=<id>`
+- `ranges=[{"start":"...","end":"..."}]`
+- `onThisDay=true`
+
+Response:
+
+```json
+{
+  "mediaItems": [
+    {
+      "id": "media/mmdd=04-04/owner=1/ts=2024-04-04T19:13:00Z_x.jpg",
+      "baseUrl": "https://...",
+      "mediaMetadata": { "creationTime": "2024-04-04T19:13:00.000Z" }
+    }
+  ],
+  "nextPageToken": "..."
+}
+```
+
+### Init upload
+
+`POST /media`
+
+```json
+{
+  "action": "init-upload",
+  "filename": "IMG_1234.jpg",
+  "mimeType": "image/jpeg",
+  "capturedAt": "2024-04-04T19:13:00Z",
+  "owner": "1"
+}
+```
+
+Response includes `uploadUrl` and final `key`.
+
+## Migration from Google Photos
+
+1. Export both users with Google Takeout (Google Photos).
+2. Unpack archives locally.
+3. For each file, determine capture time (EXIF first, fallback to sidecar metadata).
+4. Build key in the format above.
+5. Upload originals to S3 using your preferred script/tool.
+6. Validate:
+   - object count
+   - total bytes
+   - random checksum spot checks
+7. Open diary entries and verify `/media?date=...` returns expected files.
+
+## Next implementation slice
+
+- Add Android native uploader app (WorkManager + MediaStore) for true background sync
+- Add lifecycle policy: Standard -> Glacier Instant Retrieval after 30 days
+- Add optional MIME/size validation before issuing upload URLs

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
   },
   "types": "lib/",
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1024.0",
+    "@aws-sdk/s3-request-presigner": "^3.1024.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@feathersjs/authentication": "^5.0.44",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@aws-sdk/client-s3':
+        specifier: ^3.1024.0
+        version: 3.1024.0
+      '@aws-sdk/s3-request-presigner':
+        specifier: ^3.1024.0
+        version: 3.1024.0
       '@emotion/react':
         specifier: ^11.14.0
         version: 11.14.0(@types/react@19.2.14)(react@19.2.4)
@@ -290,6 +296,173 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       ajv: '>=8'
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/crc32c@5.2.0':
+    resolution: {integrity: sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==}
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-s3@3.1024.0':
+    resolution: {integrity: sha512-8qdO5aLCzaf9l0RdrSBW1iIroRKP2QBqtZ6lkrtHKiaaH0B18xEn+lrEgiN/eCf3uRAYk4cqbnI2XcWzm+7dDQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.973.26':
+    resolution: {integrity: sha512-A/E6n2W42ruU+sfWk+mMUOyVXbsSgGrY3MJ9/0Az5qUdG67y8I6HYzzoAa+e/lzxxl1uCYmEL6BTMi9ZiZnplQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/crc64-nvme@3.972.5':
+    resolution: {integrity: sha512-2VbTstbjKdT+yKi8m7b3a9CiVac+pL/IY2PHJwsaGkkHmuuqkJZIErPck1h6P3T9ghQMLSdMPyW6Qp7Di5swFg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.24':
+    resolution: {integrity: sha512-FWg8uFmT6vQM7VuzELzwVo5bzExGaKHdubn0StjgrcU5FvuLExUe+k06kn/40uKv59rYzhez8eFNM4yYE/Yb/w==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.26':
+    resolution: {integrity: sha512-CY4ppZ+qHYqcXqBVi//sdHST1QK3KzOEiLtpLsc9W2k2vfZPKExGaQIsOwcyvjpjUEolotitmd3mUNY56IwDEA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.28':
+    resolution: {integrity: sha512-wXYvq3+uQcZV7k+bE4yDXCTBdzWTU9x/nMiKBfzInmv6yYK1veMK0AKvRfRBd72nGWYKcL6AxwiPg9z/pYlgpw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.28':
+    resolution: {integrity: sha512-ZSTfO6jqUTCysbdBPtEX5OUR//3rbD0lN7jO3sQeS2Gjr/Y+DT6SbIJ0oT2cemNw3UzKu97sNONd1CwNMthuZQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.29':
+    resolution: {integrity: sha512-clSzDcvndpFJAggLDnDb36sPdlZYyEs5Zm6zgZjjUhwsJgSWiWKwFIXUVBcbruidNyBdbpOv2tNDL9sX8y3/0g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.24':
+    resolution: {integrity: sha512-Q2k/XLrFXhEztPHqj4SLCNID3hEPdlhh1CDLBpNnM+1L8fq7P+yON9/9M1IGN/dA5W45v44ylERfXtDAlmMNmw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.28':
+    resolution: {integrity: sha512-IoUlmKMLEITFn1SiCTjPfR6KrE799FBo5baWyk/5Ppar2yXZoUdaRqZzJzK6TcJxx450M8m8DbpddRVYlp5R/A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.28':
+    resolution: {integrity: sha512-d+6h0SD8GGERzKe27v5rOzNGKOl0D+l0bWJdqrxH8WSQzHzjsQFIAPgIeOTUwBHVsKKwtSxc91K/SWax6XgswQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.8':
+    resolution: {integrity: sha512-WR525Rr2QJSETa9a050isktyWi/4yIGcmY3BQ1kpHqb0LqUglQHCS8R27dTJxxWNZvQ0RVGtEZjTCbZJpyF3Aw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-expect-continue@3.972.8':
+    resolution: {integrity: sha512-5DTBTiotEES1e2jOHAq//zyzCjeMB78lEHd35u15qnrid4Nxm7diqIf9fQQ3Ov0ChH1V3Vvt13thOnrACmfGVQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.6':
+    resolution: {integrity: sha512-YckB8k1ejbyCg/g36gUMFLNzE4W5cERIa4MtsdO+wpTmJEP0+TB7okWIt7d8TDOvnb7SwvxJ21E4TGOBxFpSWQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.8':
+    resolution: {integrity: sha512-wAr2REfKsqoKQ+OkNqvOShnBoh+nkPurDKW7uAeVSu6kUECnWlSJiPvnoqxGlfousEY/v9LfS9sNc46hjSYDIQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-location-constraint@3.972.8':
+    resolution: {integrity: sha512-KaUoFuoFPziIa98DSQsTPeke1gvGXlc5ZGMhy+b+nLxZ4A7jmJgLzjEF95l8aOQN2T/qlPP3MrAyELm8ExXucw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.8':
+    resolution: {integrity: sha512-CWl5UCM57WUFaFi5kB7IBY1UmOeLvNZAZ2/OZ5l20ldiJ3TiIz1pC65gYj8X0BCPWkeR1E32mpsCk1L1I4n+lA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.9':
+    resolution: {integrity: sha512-/Wt5+CT8dpTFQxEJ9iGy/UGrXr7p2wlIOEHvIr/YcHYByzoLjrqkYqXdJjd9UIgWjv7eqV2HnFJen93UTuwfTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.27':
+    resolution: {integrity: sha512-gomO6DZwx+1D/9mbCpcqO5tPBqYBK7DtdgjTIjZ4yvfh/S7ETwAPS0XbJgP2JD8Ycr5CwVrEkV1sFtu3ShXeOw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-ssec@3.972.8':
+    resolution: {integrity: sha512-wqlK0yO/TxEC2UsY9wIlqeeutF6jjLe0f96Pbm40XscTo57nImUk9lBcw0dPgsm0sppFtAkSlDrfpK+pC30Wqw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.28':
+    resolution: {integrity: sha512-cfWZFlVh7Va9lRay4PN2A9ARFzaBYcA097InT5M2CdRS05ECF5yaz86jET8Wsl2WcyKYEvVr/QNmKtYtafUHtQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.996.18':
+    resolution: {integrity: sha512-c7ZSIXrESxHKx2Mcopgd8AlzZgoXMr20fkx5ViPWPOLBvmyhw9VwJx/Govg8Ef/IhEon5R9l53Z8fdYSEmp6VA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.10':
+    resolution: {integrity: sha512-1dq9ToC6e070QvnVhhbAs3bb5r6cQ10gTVc6cyRV5uvQe7P138TV2uG2i6+Yok4bAkVAcx5AqkTEBUvWEtBlsQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/s3-request-presigner@3.1024.0':
+    resolution: {integrity: sha512-KNoGsXnTfBxPqrtV2Owd4mrLnhTHRsOz6Hdaz+As5czGMQuPchoRvG1BJzn2NFRGLt/HSJAXVn+G6IhtRIDe+Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.15':
+    resolution: {integrity: sha512-Ukw2RpqvaL96CjfH/FgfBmy/ZosHBqoHBCFsN61qGg99F33vpntIVii8aNeh65XuOja73arSduskoa4OJea9RQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1021.0':
+    resolution: {integrity: sha512-TKY6h9spUk3OLs5v1oAgW9mAeBE3LAGNBwJokLy96wwmd4W2v/tYlXseProyed9ValDj2u1jK/4Rg1T+1NXyJA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.6':
+    resolution: {integrity: sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.996.5':
+    resolution: {integrity: sha512-Uh93L5sXFNbyR5sEPMzUU8tJ++Ku97EY4udmC01nB8Zu+xfBPwpIwJ6F7snqQeq8h2pf+8SGN5/NoytfKgYPIw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-format-url@3.972.8':
+    resolution: {integrity: sha512-J6DS9oocrgxM8xlUTTmQOuwRF6rnAGEujAN9SAzllcrQmwn5iJ58ogxy3SEhD0Q7JZvlA5jvIXBkpQRqEqlE9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.972.8':
+    resolution: {integrity: sha512-B3KGXJviV2u6Cdw2SDY2aDhoJkVfY/Q/Trwk2CMSkikE1Oi6gRzxhvhIfiRpHfmIsAhV4EA54TVEX8K6CbHbkA==}
+
+  '@aws-sdk/util-user-agent-node@3.973.14':
+    resolution: {integrity: sha512-vNSB/DYaPOyujVZBg/zUznH9QC142MaTHVmaFlF7uzzfg3CgT9f/l4C0Yi+vU/tbBhxVcXVB90Oohk5+o+ZbWw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.972.16':
+    resolution: {integrity: sha512-iu2pyvaqmeatIJLURLqx9D+4jKAdTH20ntzB6BFwjyN7V960r4jK32mx0Zf7YbtOYAbmbtQfDNuL60ONinyw7A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1510,6 +1683,218 @@ packages:
   '@sinonjs/fake-timers@15.3.0':
     resolution: {integrity: sha512-m2xozxSfCIxjDdvbhIWazlP2i2aha/iUmbl94alpsIbd3iLTfeXgfBVbwyWogB6l++istyGZqamgA/EcqYf+Bg==}
 
+  '@smithy/chunked-blob-reader-native@4.2.3':
+    resolution: {integrity: sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/chunked-blob-reader@5.2.2':
+    resolution: {integrity: sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/config-resolver@4.4.13':
+    resolution: {integrity: sha512-iIzMC5NmOUP6WL6o8iPBjFhUhBZ9pPjpUpQYWMUFQqKyXXzOftbfK8zcQCz/jFV1Psmf05BK5ypx4K2r4Tnwdg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.23.13':
+    resolution: {integrity: sha512-J+2TT9D6oGsUVXVEMvz8h2EmdVnkBiy2auCie4aSJMvKlzUtO5hqjEzXhoCUkIMo7gAYjbQcN0g/MMSXEhDs1Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.12':
+    resolution: {integrity: sha512-cr2lR792vNZcYMriSIj+Um3x9KWrjcu98kn234xA6reOAFMmbRpQMOv8KPgEmLLtx3eldU6c5wALKFqNOhugmg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-codec@4.2.12':
+    resolution: {integrity: sha512-FE3bZdEl62ojmy8x4FHqxq2+BuOHlcxiH5vaZ6aqHJr3AIZzwF5jfx8dEiU/X0a8RboyNDjmXjlbr8AdEyLgiA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-browser@4.2.12':
+    resolution: {integrity: sha512-XUSuMxlTxV5pp4VpqZf6Sa3vT/Q75FVkLSpSSE3KkWBvAQWeuWt1msTv8fJfgA4/jcJhrbrbMzN1AC/hvPmm5A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-config-resolver@4.3.12':
+    resolution: {integrity: sha512-7epsAZ3QvfHkngz6RXQYseyZYHlmWXSTPOfPmXkiS+zA6TBNo1awUaMFL9vxyXlGdoELmCZyZe1nQE+imbmV+Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-node@4.2.12':
+    resolution: {integrity: sha512-D1pFuExo31854eAvg89KMn9Oab/wEeJR6Buy32B49A9Ogdtx5fwZPqBHUlDzaCDpycTFk2+fSQgX689Qsk7UGA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-universal@4.2.12':
+    resolution: {integrity: sha512-+yNuTiyBACxOJUTvbsNsSOfH9G9oKbaJE1lNL3YHpGcuucl6rPZMi3nrpehpVOVR2E07YqFFmtwpImtpzlouHQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.15':
+    resolution: {integrity: sha512-T4jFU5N/yiIfrtrsb9uOQn7RdELdM/7HbyLNr6uO/mpkj1ctiVs7CihVr51w4LyQlXWDpXFn4BElf1WmQvZu/A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-blob-browser@4.2.13':
+    resolution: {integrity: sha512-YrF4zWKh+ghLuquldj6e/RzE3xZYL8wIPfkt0MqCRphVICjyyjH8OwKD7LLlKpVEbk4FLizFfC1+gwK6XQdR3g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.2.12':
+    resolution: {integrity: sha512-QhBYbGrbxTkZ43QoTPrK72DoYviDeg6YKDrHTMJbbC+A0sml3kSjzFtXP7BtbyJnXojLfTQldGdUR0RGD8dA3w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-stream-node@4.2.12':
+    resolution: {integrity: sha512-O3YbmGExeafuM/kP7Y8r6+1y0hIh3/zn6GROx0uNlB54K9oihAL75Qtc+jFfLNliTi6pxOAYZrRKD9A7iA6UFw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.12':
+    resolution: {integrity: sha512-/4F1zb7Z8LOu1PalTdESFHR0RbPwHd3FcaG1sI3UEIriQTWakysgJr65lc1jj6QY5ye7aFsisajotH6UhWfm/g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.2':
+    resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/md5-js@4.2.12':
+    resolution: {integrity: sha512-W/oIpHCpWU2+iAkfZYyGWE+qkpuf3vEXHLxQQDx9FPNZTTdnul0dZ2d/gUFrtQ5je1G2kp4cjG0/24YueG2LbQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-content-length@4.2.12':
+    resolution: {integrity: sha512-YE58Yz+cvFInWI/wOTrB+DbvUVz/pLn5mC5MvOV4fdRUc6qGwygyngcucRQjAhiCEbmfLOXX0gntSIcgMvAjmA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.28':
+    resolution: {integrity: sha512-p1gfYpi91CHcs5cBq982UlGlDrxoYUX6XdHSo91cQ2KFuz6QloHosO7Jc60pJiVmkWrKOV8kFYlGFFbQ2WUKKQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.4.46':
+    resolution: {integrity: sha512-SpvWNNOPOrKQGUqZbEPO+es+FRXMWvIyzUKUOYdDgdlA6BdZj/R58p4umoQ76c2oJC44PiM7mKizyyex1IJzow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.16':
+    resolution: {integrity: sha512-beqfV+RZ9RSv+sQqor3xroUUYgRFCGRw6niGstPG8zO9LgTl0B0MCucxjmrH/2WwksQN7UUgI7KNANoZv+KALA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.2.12':
+    resolution: {integrity: sha512-kruC5gRHwsCOuyCd4ouQxYjgRAym2uDlCvQ5acuMtRrcdfg7mFBg6blaxcJ09STpt3ziEkis6bhg1uwrWU7txw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.12':
+    resolution: {integrity: sha512-tr2oKX2xMcO+rBOjobSwVAkV05SIfUKz8iI53rzxEmgW3GOOPOv0UioSDk+J8OpRQnpnhsO3Af6IEBabQBVmiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.5.1':
+    resolution: {integrity: sha512-ejjxdAXjkPIs9lyYyVutOGNOraqUE9v/NjGMKwwFrfOM354wfSD8lmlj8hVwUzQmlLLF4+udhfCX9Exnbmvfzw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.12':
+    resolution: {integrity: sha512-jqve46eYU1v7pZ5BM+fmkbq3DerkSluPr5EhvOcHxygxzD05ByDRppRwRPPpFrsFo5yDtCYLKu+kreHKVrvc7A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.12':
+    resolution: {integrity: sha512-fit0GZK9I1xoRlR4jXmbLhoN0OdEpa96ul8M65XdmXnxXkuMxM0Y8HDT0Fh0Xb4I85MBvBClOzgSrV1X2s1Hxw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.12':
+    resolution: {integrity: sha512-6wTZjGABQufekycfDGMEB84BgtdOE/rCVTov+EDXQ8NHKTUNIp/j27IliwP7tjIU9LR+sSzyGBOXjeEtVgzCHg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-parser@4.2.12':
+    resolution: {integrity: sha512-P2OdvrgiAKpkPNKlKUtWbNZKB1XjPxM086NeVhK+W+wI46pIKdWBe5QyXvhUm3MEcyS/rkLvY8rZzyUdmyDZBw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.2.12':
+    resolution: {integrity: sha512-LlP29oSQN0Tw0b6D0Xo6BIikBswuIiGYbRACy5ujw/JgWSzTdYj46U83ssf6Ux0GyNJVivs2uReU8pt7Eu9okQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.4.7':
+    resolution: {integrity: sha512-HrOKWsUb+otTeo1HxVWeEb99t5ER1XrBi/xka2Wv6NVmTbuCUC1dvlrksdvxFtODLBjsC+PHK+fuy2x/7Ynyiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.12':
+    resolution: {integrity: sha512-B/FBwO3MVOL00DaRSXfXfa/TRXRheagt/q5A2NM13u7q+sHS59EOVGQNfG7DkmVtdQm5m3vOosoKAXSqn/OEgw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.12.8':
+    resolution: {integrity: sha512-aJaAX7vHe5i66smoSSID7t4rKY08PbD8EBU7DOloixvhOozfYWdcSYE4l6/tjkZ0vBZhGjheWzB2mh31sLgCMA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.13.1':
+    resolution: {integrity: sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.12':
+    resolution: {integrity: sha512-wOPKPEpso+doCZGIlr+e1lVI6+9VAKfL4kZWFgzVgGWY2hZxshNKod4l2LXS3PRC9otH/JRSjtEHqQ/7eLciRA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.3.2':
+    resolution: {integrity: sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.2.2':
+    resolution: {integrity: sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.2.3':
+    resolution: {integrity: sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@4.2.2':
+    resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-config-provider@4.2.2':
+    resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-browser@4.3.44':
+    resolution: {integrity: sha512-eZg6XzaCbVr2S5cAErU5eGBDaOVTuTo1I65i4tQcHENRcZ8rMWhQy1DaIYUSLyZjsfXvmCqZrstSMYyGFocvHA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.48':
+    resolution: {integrity: sha512-FqOKTlqSaoV3nzO55pMs5NBnZX8EhoI0DGmn9kbYeXWppgHD6dchyuj2HLqp4INJDJbSrj6OFYJkAh/WhSzZPg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.3.3':
+    resolution: {integrity: sha512-VACQVe50j0HZPjpwWcjyT51KUQ4AnsvEaQ2lKHOSL4mNLD0G9BjEniQ+yCt1qqfKfiAHRAts26ud7hBjamrwig==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.2':
+    resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.2.12':
+    resolution: {integrity: sha512-Er805uFUOvgc0l8nv0e0su0VFISoxhJ/AwOn3gL2NWNY2LUEldP5WtVcRYSQBcjg0y9NfG8JYrCJaYDpupBHJQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.2.13':
+    resolution: {integrity: sha512-qQQsIvL0MGIbUjeSrg0/VlQ3jGNKyM3/2iU3FPNgy01z+Sp4OvcaxbgIoFOTvB61ZoohtutuOvOcgmhbD0katQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.21':
+    resolution: {integrity: sha512-KzSg+7KKywLnkoKejRtIBXDmwBfjGvg1U1i/etkC7XSWUyFCoLno1IohV2c74IzQqdhX5y3uE44r/8/wuK+A7Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-uri-escape@4.2.2':
+    resolution: {integrity: sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.2.2':
+    resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-waiter@4.2.14':
+    resolution: {integrity: sha512-2zqq5o/oizvMaFUlNiTyZ7dbgYv1a893aGut2uaxtbzTx/VYYnRxWzDHuD/ftgcw94ffenua+ZNLrbqwUYE+Bg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/uuid@1.1.2':
+    resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
+    engines: {node: '>=18.0.0'}
+
   '@so-ric/colorspace@1.1.6':
     resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
 
@@ -2209,6 +2594,9 @@ packages:
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
     engines: {node: '>=18'}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.13:
     resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
@@ -2969,6 +3357,13 @@ packages:
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-xml-builder@1.1.4:
+    resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
+
+  fast-xml-parser@5.5.8:
+    resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
+    hasBin: true
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -4423,6 +4818,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.2.1:
+    resolution: {integrity: sha512-d7gQQmLvAKXKXE2GeP9apIGbMYKz88zWdsn/BN2HRWVQsDFdUY36WSLTY0Jvd4HWi7Fb30gQ62oAOzdgJA6fZw==}
+    engines: {node: '>=14.0.0'}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -5064,6 +5463,9 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strnum@2.2.2:
+    resolution: {integrity: sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -5650,6 +6052,468 @@ snapshots:
       ajv: 8.18.0
       jsonpointer: 5.0.1
       leven: 3.1.0
+
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.6
+      tslib: 2.8.1
+
+  '@aws-crypto/crc32c@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.6
+      tslib: 2.8.1
+
+  '@aws-crypto/sha1-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.6
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1024.0':
+    dependencies:
+      '@aws-crypto/sha1-browser': 5.2.0
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/credential-provider-node': 3.972.29
+      '@aws-sdk/middleware-bucket-endpoint': 3.972.8
+      '@aws-sdk/middleware-expect-continue': 3.972.8
+      '@aws-sdk/middleware-flexible-checksums': 3.974.6
+      '@aws-sdk/middleware-host-header': 3.972.8
+      '@aws-sdk/middleware-location-constraint': 3.972.8
+      '@aws-sdk/middleware-logger': 3.972.8
+      '@aws-sdk/middleware-recursion-detection': 3.972.9
+      '@aws-sdk/middleware-sdk-s3': 3.972.27
+      '@aws-sdk/middleware-ssec': 3.972.8
+      '@aws-sdk/middleware-user-agent': 3.972.28
+      '@aws-sdk/region-config-resolver': 3.972.10
+      '@aws-sdk/signature-v4-multi-region': 3.996.15
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-endpoints': 3.996.5
+      '@aws-sdk/util-user-agent-browser': 3.972.8
+      '@aws-sdk/util-user-agent-node': 3.973.14
+      '@smithy/config-resolver': 4.4.13
+      '@smithy/core': 3.23.13
+      '@smithy/eventstream-serde-browser': 4.2.12
+      '@smithy/eventstream-serde-config-resolver': 4.3.12
+      '@smithy/eventstream-serde-node': 4.2.12
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/hash-blob-browser': 4.2.13
+      '@smithy/hash-node': 4.2.12
+      '@smithy/hash-stream-node': 4.2.12
+      '@smithy/invalid-dependency': 4.2.12
+      '@smithy/md5-js': 4.2.12
+      '@smithy/middleware-content-length': 4.2.12
+      '@smithy/middleware-endpoint': 4.4.28
+      '@smithy/middleware-retry': 4.4.46
+      '@smithy/middleware-serde': 4.2.16
+      '@smithy/middleware-stack': 4.2.12
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/node-http-handler': 4.5.1
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/smithy-client': 4.12.8
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.44
+      '@smithy/util-defaults-mode-node': 4.2.48
+      '@smithy/util-endpoints': 3.3.3
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-retry': 4.2.13
+      '@smithy/util-stream': 4.5.21
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/util-waiter': 4.2.14
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/core@3.973.26':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/xml-builder': 3.972.16
+      '@smithy/core': 3.23.13
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/property-provider': 4.2.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/signature-v4': 5.3.12
+      '@smithy/smithy-client': 4.12.8
+      '@smithy/types': 4.13.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/crc64-nvme@3.972.5':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.24':
+    dependencies:
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/types': 3.973.6
+      '@smithy/property-provider': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.26':
+    dependencies:
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/types': 3.973.6
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/node-http-handler': 4.5.1
+      '@smithy/property-provider': 4.2.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/smithy-client': 4.12.8
+      '@smithy/types': 4.13.1
+      '@smithy/util-stream': 4.5.21
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.28':
+    dependencies:
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/credential-provider-env': 3.972.24
+      '@aws-sdk/credential-provider-http': 3.972.26
+      '@aws-sdk/credential-provider-login': 3.972.28
+      '@aws-sdk/credential-provider-process': 3.972.24
+      '@aws-sdk/credential-provider-sso': 3.972.28
+      '@aws-sdk/credential-provider-web-identity': 3.972.28
+      '@aws-sdk/nested-clients': 3.996.18
+      '@aws-sdk/types': 3.973.6
+      '@smithy/credential-provider-imds': 4.2.12
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.28':
+    dependencies:
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/nested-clients': 3.996.18
+      '@aws-sdk/types': 3.973.6
+      '@smithy/property-provider': 4.2.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.29':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.24
+      '@aws-sdk/credential-provider-http': 3.972.26
+      '@aws-sdk/credential-provider-ini': 3.972.28
+      '@aws-sdk/credential-provider-process': 3.972.24
+      '@aws-sdk/credential-provider-sso': 3.972.28
+      '@aws-sdk/credential-provider-web-identity': 3.972.28
+      '@aws-sdk/types': 3.973.6
+      '@smithy/credential-provider-imds': 4.2.12
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-process@3.972.24':
+    dependencies:
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/types': 3.973.6
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.28':
+    dependencies:
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/nested-clients': 3.996.18
+      '@aws-sdk/token-providers': 3.1021.0
+      '@aws-sdk/types': 3.973.6
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.28':
+    dependencies:
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/nested-clients': 3.996.18
+      '@aws-sdk/types': 3.973.6
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/middleware-bucket-endpoint@3.972.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-expect-continue@3.972.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-flexible-checksums@3.974.6':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@aws-crypto/crc32c': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/crc64-nvme': 3.972.5
+      '@aws-sdk/types': 3.973.6
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-stream': 4.5.21
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-host-header@3.972.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-location-constraint@3.972.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.972.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.9':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.27':
+    dependencies:
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.23.13
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/signature-v4': 5.3.12
+      '@smithy/smithy-client': 4.12.8
+      '@smithy/types': 4.13.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-stream': 4.5.21
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-ssec@3.972.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.28':
+    dependencies:
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-endpoints': 3.996.5
+      '@smithy/core': 3.23.13
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-retry': 4.2.13
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.996.18':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/middleware-host-header': 3.972.8
+      '@aws-sdk/middleware-logger': 3.972.8
+      '@aws-sdk/middleware-recursion-detection': 3.972.9
+      '@aws-sdk/middleware-user-agent': 3.972.28
+      '@aws-sdk/region-config-resolver': 3.972.10
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-endpoints': 3.996.5
+      '@aws-sdk/util-user-agent-browser': 3.972.8
+      '@aws-sdk/util-user-agent-node': 3.973.14
+      '@smithy/config-resolver': 4.4.13
+      '@smithy/core': 3.23.13
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/hash-node': 4.2.12
+      '@smithy/invalid-dependency': 4.2.12
+      '@smithy/middleware-content-length': 4.2.12
+      '@smithy/middleware-endpoint': 4.4.28
+      '@smithy/middleware-retry': 4.4.46
+      '@smithy/middleware-serde': 4.2.16
+      '@smithy/middleware-stack': 4.2.12
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/node-http-handler': 4.5.1
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/smithy-client': 4.12.8
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.44
+      '@smithy/util-defaults-mode-node': 4.2.48
+      '@smithy/util-endpoints': 3.3.3
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-retry': 4.2.13
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@smithy/config-resolver': 4.4.13
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/s3-request-presigner@3.1024.0':
+    dependencies:
+      '@aws-sdk/signature-v4-multi-region': 3.996.15
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-format-url': 3.972.8
+      '@smithy/middleware-endpoint': 4.4.28
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/smithy-client': 4.12.8
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.15':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.27
+      '@aws-sdk/types': 3.973.6
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/signature-v4': 5.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1021.0':
+    dependencies:
+      '@aws-sdk/core': 3.973.26
+      '@aws-sdk/nested-clients': 3.996.18
+      '@aws-sdk/types': 3.973.6
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/types@3.973.6':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.996.5':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-endpoints': 3.3.3
+      tslib: 2.8.1
+
+  '@aws-sdk/util-format-url@3.972.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@smithy/querystring-builder': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@smithy/types': 4.13.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.973.14':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.28
+      '@aws-sdk/types': 3.973.6
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.16':
+    dependencies:
+      '@smithy/types': 4.13.1
+      fast-xml-parser: 5.5.8
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -7238,6 +8102,338 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@smithy/chunked-blob-reader-native@4.2.3':
+    dependencies:
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/chunked-blob-reader@5.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/config-resolver@4.4.13':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-endpoints': 3.3.3
+      '@smithy/util-middleware': 4.2.12
+      tslib: 2.8.1
+
+  '@smithy/core@3.23.13':
+    dependencies:
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-stream': 4.5.21
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.12':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/property-provider': 4.2.12
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      tslib: 2.8.1
+
+  '@smithy/eventstream-codec@4.2.12':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.13.1
+      '@smithy/util-hex-encoding': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-browser@4.2.12':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-config-resolver@4.3.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-node@4.2.12':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-universal@4.2.12':
+    dependencies:
+      '@smithy/eventstream-codec': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.3.15':
+    dependencies:
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/querystring-builder': 4.2.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/hash-blob-browser@4.2.13':
+    dependencies:
+      '@smithy/chunked-blob-reader': 5.2.2
+      '@smithy/chunked-blob-reader-native': 4.2.3
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/hash-node@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/hash-stream-node@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/md5-js@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/middleware-content-length@4.2.12':
+    dependencies:
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.4.28':
+    dependencies:
+      '@smithy/core': 3.23.13
+      '@smithy/middleware-serde': 4.2.16
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-middleware': 4.2.12
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.4.46':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/service-error-classification': 4.2.12
+      '@smithy/smithy-client': 4.12.8
+      '@smithy/types': 4.13.1
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-retry': 4.2.13
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.2.16':
+    dependencies:
+      '@smithy/core': 3.23.13
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.12':
+    dependencies:
+      '@smithy/property-provider': 4.2.12
+      '@smithy/shared-ini-file-loader': 4.4.7
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.5.1':
+    dependencies:
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/querystring-builder': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/property-provider@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/querystring-builder@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      '@smithy/util-uri-escape': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/service-error-classification@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+
+  '@smithy/shared-ini-file-loader@4.4.7':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.3.12':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-uri-escape': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.12.8':
+    dependencies:
+      '@smithy/core': 3.23.13
+      '@smithy/middleware-endpoint': 4.4.28
+      '@smithy/middleware-stack': 4.2.12
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/types': 4.13.1
+      '@smithy/util-stream': 4.5.21
+      tslib: 2.8.1
+
+  '@smithy/types@4.13.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.12':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.3.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.2.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@4.2.2':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-config-provider@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-browser@4.3.44':
+    dependencies:
+      '@smithy/property-provider': 4.2.12
+      '@smithy/smithy-client': 4.12.8
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.2.48':
+    dependencies:
+      '@smithy/config-resolver': 4.4.13
+      '@smithy/credential-provider-imds': 4.2.12
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/property-provider': 4.2.12
+      '@smithy/smithy-client': 4.12.8
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.3.3':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.2.12':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.2.13':
+    dependencies:
+      '@smithy/service-error-classification': 4.2.12
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.21':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/node-http-handler': 4.5.1
+      '@smithy/types': 4.13.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.2.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-waiter@4.2.14':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@smithy/uuid@1.1.2':
+    dependencies:
+      tslib: 2.8.1
+
   '@so-ric/colorspace@1.1.6':
     dependencies:
       color: 5.0.3
@@ -8059,6 +9255,8 @@ snapshots:
       type-is: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.13:
     dependencies:
@@ -8987,6 +10185,16 @@ snapshots:
   fast-levenshtein@2.0.6: {}
 
   fast-uri@3.1.0: {}
+
+  fast-xml-builder@1.1.4:
+    dependencies:
+      path-expression-matcher: 1.2.1
+
+  fast-xml-parser@5.5.8:
+    dependencies:
+      fast-xml-builder: 1.1.4
+      path-expression-matcher: 1.2.1
+      strnum: 2.2.2
 
   fastq@1.20.1:
     dependencies:
@@ -10882,6 +12090,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-expression-matcher@1.2.1: {}
+
   path-is-absolute@1.0.1: {}
 
   path-key@2.0.1: {}
@@ -11625,6 +12835,8 @@ snapshots:
   strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
+
+  strnum@2.2.2: {}
 
   style-to-js@1.1.21:
     dependencies:

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -19,6 +19,7 @@ import blogPostBlock from './blog-post-block/blog-post-block.service';
 import contextSegments from './context-segments/context-segments.service';
 import watch from './watch/watch.service';
 import passwordManagement from './password-management/password-management.service';
+import media from './media/media.service';
 // Don't remove this comment. It's needed to format import lines nicely.
 
 export default function (app: Application): void {
@@ -42,4 +43,5 @@ export default function (app: Application): void {
   app.configure(contextSegments);
   app.configure(watch);
   app.configure(passwordManagement);
+  app.configure(media);
 }

--- a/server/services/media/media.class.ts
+++ b/server/services/media/media.class.ts
@@ -1,0 +1,260 @@
+import { randomUUID } from 'crypto';
+import { Params } from '@feathersjs/feathers';
+import { BadRequest, GeneralError } from '@feathersjs/errors';
+import {
+  GetObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import { Application } from '../../declarations';
+
+dayjs.extend(utc);
+
+type MediaQuery = {
+  date?: string;
+  mmdd?: string;
+  owner?: string;
+  ranges?: string;
+  pageToken?: string;
+  pageSize?: string | number;
+  onThisDay?: string | number | boolean;
+};
+
+type UploadInitBody = {
+  action: 'init-upload';
+  filename: string;
+  mimeType?: string;
+  capturedAt?: string;
+  owner?: string;
+};
+
+type MediaRange = {
+  start: string;
+  end: string;
+};
+
+const MAX_PAGE_SIZE = 100;
+const DEFAULT_PAGE_SIZE = 24;
+
+const toBool = (value: MediaQuery['onThisDay']) =>
+  value === true || value === 'true' || value === 1 || value === '1';
+
+const toMmDd = (date: string) => dayjs.utc(date).format('MM-DD');
+
+const toIsoFromKey = (key: string) => {
+  const tsMatch = key.match(/\/ts=([^_\/]+)_/);
+  if (!tsMatch?.[1]) {
+    return null;
+  }
+  const parsed = dayjs.utc(decodeURIComponent(tsMatch[1]));
+  return parsed.isValid() ? parsed.toISOString() : null;
+};
+
+const keyContainsOwner = (key: string, owner?: string) =>
+  !owner || key.includes(`/owner=${owner}/`);
+
+const isWithinRanges = (isoDate: string, ranges: MediaRange[]) =>
+  ranges.some((range) => {
+    const date = dayjs.utc(isoDate).valueOf();
+    const start = dayjs.utc(range.start).startOf('day').valueOf();
+    const end = dayjs.utc(range.end).endOf('day').valueOf();
+    return date >= start && date <= end;
+  });
+
+const buildKey = ({
+  capturedAt,
+  owner,
+  filename,
+  prefix,
+}: {
+  capturedAt?: string;
+  owner: string;
+  filename: string;
+  prefix: string;
+}) => {
+  const captured = dayjs.utc(capturedAt || new Date().toISOString());
+  if (!captured.isValid()) {
+    throw new BadRequest('Invalid capturedAt value');
+  }
+
+  const extension = filename.includes('.')
+    ? `.${filename.split('.').pop() || ''}`.replace(/\.+$/, '')
+    : '';
+  const ts = captured.format('YYYY-MM-DDTHH:mm:ss[Z]');
+  const mmdd = captured.format('MM-DD');
+  return `${prefix}mmdd=${mmdd}/owner=${owner}/ts=${ts}_${randomUUID()}${extension}`;
+};
+
+export class MediaService {
+  app: Application;
+  s3: S3Client;
+  bucket: string;
+  prefix: string;
+  getUrlTtlSeconds: number;
+  putUrlTtlSeconds: number;
+
+  constructor(app: Application) {
+    this.app = app;
+    const cfg = app.get('media') || {};
+    this.bucket = cfg.bucket || process.env.AWS_S3_BUCKET || '';
+    if (!this.bucket) {
+      throw new Error('Missing media.bucket (or AWS_S3_BUCKET) configuration');
+    }
+
+    this.getUrlTtlSeconds = Number(cfg.getUrlTtlSeconds || 300);
+    this.putUrlTtlSeconds = Number(cfg.putUrlTtlSeconds || 900);
+    this.prefix = String(cfg.prefix || 'media/').replace(/^\/+/, '');
+    if (!this.prefix.endsWith('/')) {
+      this.prefix += '/';
+    }
+    this.s3 = new S3Client({
+      region: cfg.region || process.env.AWS_REGION || 'us-east-1',
+      endpoint: cfg.endpoint || process.env.AWS_S3_ENDPOINT || undefined,
+      forcePathStyle: Boolean(cfg.forcePathStyle || process.env.AWS_S3_FORCE_PATH_STYLE === 'true'),
+    });
+  }
+
+  async find(params: Params<MediaQuery>) {
+    const query = params.query || {};
+    const pageSize = Math.min(
+      Number(query.pageSize || DEFAULT_PAGE_SIZE) || DEFAULT_PAGE_SIZE,
+      MAX_PAGE_SIZE,
+    );
+    const onThisDay = toBool(query.onThisDay);
+
+    const date = query.date ? dayjs.utc(query.date) : null;
+    if (query.date && (!date || !date.isValid())) {
+      throw new BadRequest('Invalid date query');
+    }
+
+    let ranges: MediaRange[] = [];
+    if (query.ranges) {
+      try {
+        ranges = JSON.parse(query.ranges) as MediaRange[];
+      } catch (_err) {
+        throw new BadRequest('Invalid ranges query JSON');
+      }
+    }
+
+    const targetMmdd = query.mmdd || (date ? toMmDd(date.toISOString()) : null);
+    const prefix = targetMmdd
+      ? `${this.prefix}mmdd=${targetMmdd}/`
+      : this.prefix;
+
+    let continuationToken = query.pageToken;
+    const collected: Array<{ key: string; createdAt: string }> = [];
+    let pageGuard = 0;
+
+    while (collected.length < pageSize && pageGuard < 20) {
+      pageGuard += 1;
+      const result = await this.s3.send(
+        new ListObjectsV2Command({
+          Bucket: this.bucket,
+          Prefix: prefix,
+          ContinuationToken: continuationToken,
+          MaxKeys: 1000,
+        }),
+      );
+      continuationToken = result.NextContinuationToken;
+      const objects = result.Contents || [];
+
+      for (const item of objects) {
+        if (!item.Key || !keyContainsOwner(item.Key, query.owner)) {
+          continue;
+        }
+        const createdAt = toIsoFromKey(item.Key) || item.LastModified?.toISOString();
+        if (!createdAt) {
+          continue;
+        }
+        if (date && !onThisDay && dayjs.utc(createdAt).format('YYYY-MM-DD') !== date.format('YYYY-MM-DD')) {
+          continue;
+        }
+        if (ranges.length && !isWithinRanges(createdAt, ranges)) {
+          continue;
+        }
+        collected.push({ key: item.Key, createdAt });
+      }
+
+      if (!result.IsTruncated) {
+        break;
+      }
+    }
+
+    collected.sort((a, b) => dayjs.utc(b.createdAt).valueOf() - dayjs.utc(a.createdAt).valueOf());
+    const selected = collected.slice(0, pageSize);
+
+    const mediaItems = await Promise.all(
+      selected.map(async (item) => {
+        try {
+          const baseUrl = await getSignedUrl(
+            this.s3,
+            new GetObjectCommand({
+              Bucket: this.bucket,
+              Key: item.key,
+            }),
+            { expiresIn: this.getUrlTtlSeconds },
+          );
+          return {
+            id: item.key,
+            baseUrl,
+            mediaMetadata: {
+              creationTime: item.createdAt,
+            },
+          };
+        } catch (error) {
+          throw new GeneralError('Failed to sign media URL', { error });
+        }
+      }),
+    );
+
+    return {
+      mediaItems,
+      nextPageToken: continuationToken || null,
+    };
+  }
+
+  async create(data: UploadInitBody, params: Params) {
+    if (!data || data.action !== 'init-upload') {
+      throw new BadRequest('Unsupported action. Use action="init-upload".');
+    }
+    if (!data.filename) {
+      throw new BadRequest('filename is required');
+    }
+
+    const owner = data.owner || String(params.user?.id || 'anonymous');
+    const key = buildKey({
+      capturedAt: data.capturedAt,
+      owner,
+      filename: data.filename,
+      prefix: this.prefix,
+    });
+
+    const uploadUrl = await getSignedUrl(
+      this.s3,
+      new PutObjectCommand({
+        Bucket: this.bucket,
+        Key: key,
+        ContentType: data.mimeType || 'application/octet-stream',
+        Metadata: {
+          owner,
+          captured_at: data.capturedAt || '',
+        },
+      }),
+      { expiresIn: this.putUrlTtlSeconds },
+    );
+
+    return {
+      key,
+      uploadUrl,
+      expiresIn: this.putUrlTtlSeconds,
+      method: 'PUT',
+      headers: {
+        'Content-Type': data.mimeType || 'application/octet-stream',
+      },
+    };
+  }
+}

--- a/server/services/media/media.class.ts
+++ b/server/services/media/media.class.ts
@@ -6,6 +6,7 @@ import {
   ListObjectsV2Command,
   PutObjectCommand,
   S3Client,
+  StorageClass,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import dayjs from 'dayjs';
@@ -96,6 +97,7 @@ export class MediaService {
   prefix: string;
   getUrlTtlSeconds: number;
   putUrlTtlSeconds: number;
+  uploadStorageClass?: StorageClass;
 
   constructor(app: Application) {
     this.app = app;
@@ -107,6 +109,12 @@ export class MediaService {
 
     this.getUrlTtlSeconds = Number(cfg.getUrlTtlSeconds || 300);
     this.putUrlTtlSeconds = Number(cfg.putUrlTtlSeconds || 900);
+    const uploadStorageClass = String(
+      cfg.uploadStorageClass || process.env.AWS_S3_UPLOAD_STORAGE_CLASS || '',
+    ).trim();
+    this.uploadStorageClass = uploadStorageClass
+      ? (uploadStorageClass as StorageClass)
+      : undefined;
     this.prefix = String(cfg.prefix || 'media/').replace(/^\/+/, '');
     if (!this.prefix.endsWith('/')) {
       this.prefix += '/';
@@ -239,6 +247,9 @@ export class MediaService {
         Bucket: this.bucket,
         Key: key,
         ContentType: data.mimeType || 'application/octet-stream',
+        ...(this.uploadStorageClass
+          ? { StorageClass: this.uploadStorageClass }
+          : {}),
         Metadata: {
           owner,
           captured_at: data.capturedAt || '',

--- a/server/services/media/media.class.ts
+++ b/server/services/media/media.class.ts
@@ -122,7 +122,9 @@ export class MediaService {
     this.s3 = new S3Client({
       region: cfg.region || process.env.AWS_REGION || 'us-east-1',
       endpoint: cfg.endpoint || process.env.AWS_S3_ENDPOINT || undefined,
-      forcePathStyle: Boolean(cfg.forcePathStyle || process.env.AWS_S3_FORCE_PATH_STYLE === 'true'),
+      forcePathStyle: Boolean(
+        cfg.forcePathStyle || process.env.AWS_S3_FORCE_PATH_STYLE === 'true',
+      ),
     });
   }
 
@@ -143,7 +145,7 @@ export class MediaService {
     if (query.ranges) {
       try {
         ranges = JSON.parse(query.ranges) as MediaRange[];
-      } catch (_err) {
+      } catch {
         throw new BadRequest('Invalid ranges query JSON');
       }
     }
@@ -174,11 +176,17 @@ export class MediaService {
         if (!item.Key || !keyContainsOwner(item.Key, query.owner)) {
           continue;
         }
-        const createdAt = toIsoFromKey(item.Key) || item.LastModified?.toISOString();
+        const createdAt =
+          toIsoFromKey(item.Key) || item.LastModified?.toISOString();
         if (!createdAt) {
           continue;
         }
-        if (date && !onThisDay && dayjs.utc(createdAt).format('YYYY-MM-DD') !== date.format('YYYY-MM-DD')) {
+        if (
+          date &&
+          !onThisDay &&
+          dayjs.utc(createdAt).format('YYYY-MM-DD') !==
+            date.format('YYYY-MM-DD')
+        ) {
           continue;
         }
         if (ranges.length && !isWithinRanges(createdAt, ranges)) {
@@ -192,7 +200,10 @@ export class MediaService {
       }
     }
 
-    collected.sort((a, b) => dayjs.utc(b.createdAt).valueOf() - dayjs.utc(a.createdAt).valueOf());
+    collected.sort(
+      (a, b) =>
+        dayjs.utc(b.createdAt).valueOf() - dayjs.utc(a.createdAt).valueOf(),
+    );
     const selected = collected.slice(0, pageSize);
 
     const mediaItems = await Promise.all(

--- a/server/services/media/media.hooks.ts
+++ b/server/services/media/media.hooks.ts
@@ -1,0 +1,36 @@
+import * as authentication from '@feathersjs/authentication';
+
+const { authenticate } = authentication.hooks;
+
+export default {
+  before: {
+    all: [authenticate('jwt')],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: [],
+  },
+
+  after: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: [],
+  },
+
+  error: {
+    all: [],
+    find: [],
+    get: [],
+    create: [],
+    update: [],
+    patch: [],
+    remove: [],
+  },
+};
+

--- a/server/services/media/media.hooks.ts
+++ b/server/services/media/media.hooks.ts
@@ -33,4 +33,3 @@ export default {
     remove: [],
   },
 };
-

--- a/server/services/media/media.service.ts
+++ b/server/services/media/media.service.ts
@@ -14,4 +14,3 @@ export default function (app: Application): void {
   const service = app.service('media');
   service.hooks(hooks);
 }
-

--- a/server/services/media/media.service.ts
+++ b/server/services/media/media.service.ts
@@ -1,0 +1,17 @@
+import { ServiceAddons } from '@feathersjs/feathers';
+import { Application } from '../../declarations';
+import { MediaService } from './media.class';
+import hooks from './media.hooks';
+
+declare module '../../declarations' {
+  interface ServiceTypes {
+    media: MediaService & ServiceAddons<any>;
+  }
+}
+
+export default function (app: Application): void {
+  (app as any).use('media', new MediaService(app));
+  const service = app.service('media');
+  service.hooks(hooks);
+}
+

--- a/src/Days/PostShow/PostPhotos/index.tsx
+++ b/src/Days/PostShow/PostPhotos/index.tsx
@@ -3,7 +3,7 @@ import Button from '@mui/material/Button';
 import { Dialog, Typography, Box } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import GPhotosContext from '../../../shared/context/GPhotosContext';
-import { getPhotosOnDate, photosSignIn } from '../../../shared/utils/photos';
+import { getPhotosOnDate } from '../../../shared/utils/photos';
 import { PhotoType } from '../../../shared/types';
 
 type Props = {
@@ -21,25 +21,16 @@ const PostPhotos = ({
   const [isFetched, setFetched] = React.useState(false);
   const [showImg, setShowImg] = React.useState('');
   const {
-    handleSignIn,
     value: { token: oauthToken },
   } = useContext(GPhotosContext);
 
   const getPhotos = () => {
     getPhotosOnDate(oauthToken, date)
-      .then(async ({ photos, error }) => {
+      .then(({ photos, error }) => {
         setFetched(true);
         if (error) {
-          if (error.code === 401) {
-            const newToken = await photosSignIn(handleSignIn);
-            getPhotosOnDate(newToken, date)
-              .then(({ photos }) => {
-                if (photos?.mediaItems) {
-                  setPhotos(photos.mediaItems);
-                }
-              })
-              .catch(console.log);
-          }
+          console.log(error);
+          return;
         }
         if (photos?.mediaItems) {
           setPhotos(photos.mediaItems);

--- a/src/Days/PostShow/PostPhotos/index.tsx
+++ b/src/Days/PostShow/PostPhotos/index.tsx
@@ -97,7 +97,6 @@ const PostPhotos = ({
         marginTop: (theme) => theme.spacing(1),
       }}
     >
-      {extraAction ? <Box>{extraAction}</Box> : null}
       <input
         ref={uploadInputRef}
         type="file"
@@ -106,7 +105,8 @@ const PostPhotos = ({
         hidden
         onChange={handleFileSelected}
       />
-      <Grid container spacing={1}>
+      <Grid container spacing={1} alignItems="center">
+        {extraAction ? <Box>{extraAction}</Box> : null}
         {!hideGetPhotosButton && !isFetched ? (
           <Button onClick={getPhotos}>GET PHOTOS</Button>
         ) : null}

--- a/src/Days/PostShow/PostPhotos/index.tsx
+++ b/src/Days/PostShow/PostPhotos/index.tsx
@@ -106,7 +106,9 @@ const PostPhotos = ({
         onChange={handleFileSelected}
       />
       <Grid container spacing={1}>
-        {!hideGetPhotosButton ? <Button onClick={getPhotos}>GET PHOTOS</Button> : null}
+        {!hideGetPhotosButton && !isFetched ? (
+          <Button onClick={getPhotos}>GET PHOTOS</Button>
+        ) : null}
         <Button onClick={handleUploadButtonClick} disabled={isUploading}>
           {isUploading ? 'UPLOADING...' : 'UPLOAD PHOTO'}
         </Button>

--- a/src/Days/PostShow/PostPhotos/index.tsx
+++ b/src/Days/PostShow/PostPhotos/index.tsx
@@ -92,6 +92,7 @@ const PostPhotos = ({
   return (
     <Grid
       container
+      direction="column"
       sx={{
         marginTop: (theme) => theme.spacing(1),
       }}

--- a/src/Days/PostShow/PostPhotos/index.tsx
+++ b/src/Days/PostShow/PostPhotos/index.tsx
@@ -46,10 +46,10 @@ const PostPhotos = ({
         marginTop: (theme) => theme.spacing(1),
       }}
     >
+      {extraAction ? <Box>{extraAction}</Box> : null}
       {!isFetched && !hideGetPhotosButton ? (
         <Button onClick={getPhotos}>GET PHOTOS</Button>
       ) : null}
-      {extraAction ? <Box>{extraAction}</Box> : null}
       {isFetched && !photos.length ? (
         <Typography>No photos found...</Typography>
       ) : null}

--- a/src/Days/PostShow/PostPhotos/index.tsx
+++ b/src/Days/PostShow/PostPhotos/index.tsx
@@ -3,7 +3,11 @@ import Button from '@mui/material/Button';
 import { Dialog, Typography, Box } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import GPhotosContext from '../../../shared/context/GPhotosContext';
-import { getPhotosOnDate } from '../../../shared/utils/photos';
+import {
+  getPhotosOnDate,
+  initMediaUpload,
+  uploadFileToPresignedUrl,
+} from '../../../shared/utils/photos';
 import { PhotoType } from '../../../shared/types';
 
 type Props = {
@@ -20,6 +24,8 @@ const PostPhotos = ({
   const [photos, setPhotos] = React.useState<PhotoType[]>([]);
   const [isFetched, setFetched] = React.useState(false);
   const [showImg, setShowImg] = React.useState('');
+  const [isUploading, setUploading] = React.useState(false);
+  const uploadInputRef = React.useRef<HTMLInputElement | null>(null);
   const {
     value: { token: oauthToken },
   } = useContext(GPhotosContext);
@@ -39,6 +45,50 @@ const PostPhotos = ({
       .catch(console.log);
   };
 
+  const handleUploadButtonClick = () => {
+    uploadInputRef.current?.click();
+  };
+
+  const handleFileSelected = async (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const files = event.target.files;
+    if (!files?.length) {
+      return;
+    }
+    setUploading(true);
+    try {
+      const parsedDate = new Date(date);
+      const capturedAt = Number.isNaN(parsedDate.getTime())
+        ? new Date().toISOString()
+        : parsedDate.toISOString();
+      for (const file of Array.from(files)) {
+        const { data, error } = await initMediaUpload({
+          filename: file.name,
+          mimeType: file.type,
+          capturedAt,
+        });
+        if (error || !data?.uploadUrl) {
+          throw error || new Error('Upload init failed');
+        }
+        const uploadResult = await uploadFileToPresignedUrl({
+          uploadUrl: data.uploadUrl,
+          file,
+          mimeType: file.type,
+        });
+        if (uploadResult.error) {
+          throw uploadResult.error;
+        }
+      }
+      getPhotos();
+    } catch (error) {
+      console.log(error);
+    } finally {
+      event.target.value = '';
+      setUploading(false);
+    }
+  };
+
   return (
     <Grid
       container
@@ -47,9 +97,20 @@ const PostPhotos = ({
       }}
     >
       {extraAction ? <Box>{extraAction}</Box> : null}
-      {!isFetched && !hideGetPhotosButton ? (
-        <Button onClick={getPhotos}>GET PHOTOS</Button>
-      ) : null}
+      <input
+        ref={uploadInputRef}
+        type="file"
+        accept="image/*,video/*"
+        multiple
+        hidden
+        onChange={handleFileSelected}
+      />
+      <Grid container spacing={1}>
+        {!hideGetPhotosButton ? <Button onClick={getPhotos}>GET PHOTOS</Button> : null}
+        <Button onClick={handleUploadButtonClick} disabled={isUploading}>
+          {isUploading ? 'UPLOADING...' : 'UPLOAD PHOTO'}
+        </Button>
+      </Grid>
       {isFetched && !photos.length ? (
         <Typography>No photos found...</Typography>
       ) : null}

--- a/src/Days/PostShow/index.tsx
+++ b/src/Days/PostShow/index.tsx
@@ -557,7 +557,6 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
             ) : null}
             <PostPhotos
               date={post.date}
-              hideGetPhotosButton
               extraAction={
                 weather ? (
                   <Typography

--- a/src/Days/PostShow/index.tsx
+++ b/src/Days/PostShow/index.tsx
@@ -576,18 +576,6 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
                   <Button
                     type="button"
                     onClick={handleFetchWeather}
-                    variant="text"
-                    color="primary"
-                    size="small"
-                    sx={{
-                      textTransform: 'uppercase',
-                      fontSize: 12,
-                      fontWeight: 600,
-                      letterSpacing: 0.3,
-                      minWidth: 0,
-                      padding: 0,
-                      lineHeight: 1.25,
-                    }}
                     disabled={
                       post.id === 0 ||
                       editPostMutation.isPending ||

--- a/src/Days/PostShow/index.tsx
+++ b/src/Days/PostShow/index.tsx
@@ -555,6 +555,20 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
                 ))}
               </Grid>
             ) : null}
+            {post.comments.map((comment) => (
+              <PostComment key={comment.id} comment={comment} />
+            ))}
+            {isCommentOpen ? (
+              <PostCommentEdit
+                postId={post.id}
+                onCancel={() => {
+                  setCommentOpen(false);
+                }}
+                invalidateQueries={invalidateQueries}
+              />
+            ) : (
+              ''
+            )}
             <PostPhotos
               date={post.date}
               extraAction={
@@ -587,20 +601,6 @@ const PostShow = ({ post, labels, searchTerm, invalidateQueries }: Props) => {
                 )
               }
             />
-            {post.comments.map((comment) => (
-              <PostComment key={comment.id} comment={comment} />
-            ))}
-            {isCommentOpen ? (
-              <PostCommentEdit
-                postId={post.id}
-                onCancel={() => {
-                  setCommentOpen(false);
-                }}
-                invalidateQueries={invalidateQueries}
-              />
-            ) : (
-              ''
-            )}
             <Dialog
               open={!!selectedContext}
               onClose={() => setSelectedContext(null)}

--- a/src/Days/Settings/PhotosSettings/index.tsx
+++ b/src/Days/Settings/PhotosSettings/index.tsx
@@ -1,49 +1,17 @@
-import React, { useContext } from 'react';
-import { Avatar, Typography } from '@mui/material';
+import React from 'react';
+import { Typography } from '@mui/material';
 import Grid from '@mui/material/Grid';
-import Button from '@mui/material/Button';
-import { photosSignIn, photosVerifyToken } from '../../../shared/utils/photos';
-import GPhotosContext from '../../../shared/context/GPhotosContext';
 
 const PhotosSettings = () => {
-  const {
-    handleSignIn,
-    handleSignOut,
-    value: googleUser,
-  } = useContext(GPhotosContext);
-
-  React.useEffect(() => {
-    photosVerifyToken(googleUser, handleSignOut);
-  }, []);
-
   return (
     <Grid container spacing={2}>
       <Grid size={12}>
-        <Typography variant="h6">Google Photos:</Typography>
-        {googleUser.isLoggedIn ? (
-          <Grid container spacing={2}>
-            <Grid size={12}>
-              <Typography>Logged in as:</Typography>
-            </Grid>
-            <Grid container spacing={1} alignItems="center" size={12}>
-              <Grid>
-                <Avatar src={googleUser.imageUrl} alt={googleUser.name} />
-              </Grid>
-              <Grid>
-                <Typography>{googleUser.name}</Typography>
-              </Grid>
-            </Grid>
-            <Grid size={12}>
-              <Button onClick={() => photosSignIn(handleSignIn)}>
-                Change user
-              </Button>
-            </Grid>
-          </Grid>
-        ) : (
-          <Button onClick={() => photosSignIn(handleSignIn)}>
-            Connect to Google Photos
-          </Button>
-        )}
+        <Typography variant="h6">Media Source:</Typography>
+        <Typography>
+          Photos and videos are loaded from the configured S3 bucket via the
+          <code> /media </code>
+          API.
+        </Typography>
       </Grid>
     </Grid>
   );

--- a/src/WorldMap/index.tsx
+++ b/src/WorldMap/index.tsx
@@ -129,19 +129,17 @@ function WorldMap() {
     setPhotos([]);
     setNextPageToken(undefined);
     setFetched(false);
-    getPhotosOnDate(oauthToken, null, periods).then(
-      ({ photos, error }) => {
-        setFetched(true);
-        if (error) {
-          console.log(error);
-          return;
-        }
-        if (photos?.mediaItems) {
-          setPhotos(photos.mediaItems);
-          setNextPageToken(photos?.nextPageToken);
-        }
-      },
-    );
+    getPhotosOnDate(oauthToken, null, periods).then(({ photos, error }) => {
+      setFetched(true);
+      if (error) {
+        console.log(error);
+        return;
+      }
+      if (photos?.mediaItems) {
+        setPhotos(photos.mediaItems);
+        setNextPageToken(photos?.nextPageToken);
+      }
+    });
     setShowCountry(periods);
   };
 

--- a/src/WorldMap/index.tsx
+++ b/src/WorldMap/index.tsx
@@ -17,7 +17,7 @@ import {
 } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import GPhotosContext from '../shared/context/GPhotosContext';
-import { getPhotosOnDate, photosSignIn } from '../shared/utils/photos';
+import { getPhotosOnDate } from '../shared/utils/photos';
 import { getPeriods } from '../shared/api/routes';
 import { PeriodType, PhotoType } from '../shared/types';
 import citiesList from './citiesList.json';
@@ -104,7 +104,6 @@ function WorldMap() {
   const [currZoom, setCurrZoom] = React.useState(1);
   const [nextPageToken, setNextPageToken] = React.useState();
   const {
-    handleSignIn,
     value: { token: oauthToken },
   } = useContext(GPhotosContext);
   const svgRef = useRef<SVGSVGElement>(null);
@@ -131,20 +130,11 @@ function WorldMap() {
     setNextPageToken(undefined);
     setFetched(false);
     getPhotosOnDate(oauthToken, null, periods).then(
-      async ({ photos, error }) => {
+      ({ photos, error }) => {
         setFetched(true);
         if (error) {
-          if (error.code === 401) {
-            const newToken = await photosSignIn(handleSignIn);
-            getPhotosOnDate(newToken, null, periods)
-              .then(({ photos }) => {
-                if (photos?.mediaItems) {
-                  setPhotos(photos.mediaItems);
-                  setNextPageToken(photos?.nextPageToken);
-                }
-              })
-              .catch(console.log);
-          }
+          console.log(error);
+          return;
         }
         if (photos?.mediaItems) {
           setPhotos(photos.mediaItems);

--- a/src/shared/utils/photos.js
+++ b/src/shared/utils/photos.js
@@ -1,57 +1,45 @@
-export const getPhotosOnDate = async (
-  authToken,
-  date,
-  ranges,
-  nextPageToken,
-) => {
+import { LOCAL } from '../config/const';
+import { getItemFromStorage, TOKEN_KEY } from './storage';
+
+const authHeaders = () => ({
+  Accept: 'application/json',
+  'Content-Type': 'application/json',
+  authorization: getItemFromStorage(TOKEN_KEY) || '',
+});
+
+const normalizeRanges = (ranges = []) =>
+  ranges.map((r) => ({
+    start: r.start,
+    end: r.end,
+  }));
+
+export const getPhotosOnDate = async (_authToken, date, ranges, nextPageToken) => {
   let photos = [];
   let error = null;
+
   try {
-    const response = await fetch(
-      `https://photoslibrary.googleapis.com/v1/mediaItems:search?access_token=${encodeURIComponent(
-        authToken,
-      )}`,
-      {
-        method: 'POST',
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          ...(nextPageToken ? { pageToken: nextPageToken } : {}),
-          pageSize: '24',
-          filters: {
-            dateFilter: date
-              ? {
-                  dates: {
-                    year: new Date(date).getFullYear(),
-                    month: new Date(date).getMonth() + 1,
-                    day: new Date(date).getDate(),
-                  },
-                }
-              : {
-                  ranges: ranges.map((r) => ({
-                    startDate: {
-                      year: new Date(r.start).getFullYear(),
-                      month: new Date(r.start).getMonth() + 1,
-                      day: new Date(r.start).getDate(),
-                    },
-                    endDate: {
-                      year: new Date(r.end).getFullYear(),
-                      month: new Date(r.end).getMonth() + 1,
-                      day: new Date(r.end).getDate(),
-                    },
-                  })),
-                },
-          },
-        }),
-      },
-    );
+    const params = new URLSearchParams();
+    params.set('pageSize', '24');
+    if (nextPageToken) {
+      params.set('pageToken', nextPageToken);
+    }
+    if (date) {
+      params.set('date', new Date(date).toISOString());
+    }
+    if (ranges?.length) {
+      params.set('ranges', JSON.stringify(normalizeRanges(ranges)));
+    }
+
+    const response = await fetch(`${LOCAL}/media?${params.toString()}`, {
+      method: 'GET',
+      headers: authHeaders(),
+    });
     const result = await response.json();
-    if (result && !result.error) {
+
+    if (response.ok && !result.error) {
       photos = result;
     } else {
-      error = result.error;
+      error = result.error || { code: response.status, message: 'Failed to get media' };
     }
   } catch (err) {
     error = err;
@@ -60,51 +48,7 @@ export const getPhotosOnDate = async (
   return { photos, error };
 };
 
-let client;
+export const photosSignIn = () => Promise.resolve('');
 
-const getClient = (callback) => {
-  if (client) {
-    return client;
-  }
-  client = window.google.accounts.oauth2.initTokenClient({
-    client_id:
-      import.meta.env.VITE_OAUTH_ID || import.meta.env.REACT_APP_OAUTH_ID,
-    scope: 'https://www.googleapis.com/auth/photoslibrary.readonly',
-    callback,
-  });
-  return client;
-};
+export const photosVerifyToken = async () => true;
 
-export const photosSignIn = (handleUserSignIn) => {
-  if (window.google) {
-    return new Promise((resolve) => {
-      let googleClient = getClient((tokenResponse) => {
-        const access_token = tokenResponse.access_token;
-        fetch('https://www.googleapis.com/oauth2/v1/userinfo', {
-          headers: { Authorization: `Bearer ${access_token}` },
-        })
-          .then((resp) => resp.json())
-          .then((resp) => {
-            handleUserSignIn({
-              token: access_token,
-              name: resp.name,
-              imageUrl: resp.picture,
-              expiresAt: Date.now() + tokenResponse.expires_in * 1000,
-            });
-          })
-          .catch(console.log);
-        resolve(access_token);
-      });
-      googleClient.requestAccessToken();
-    });
-  } else {
-    console.log('Google API not available');
-  }
-};
-
-export const photosVerifyToken = async (googleUser, handleSignOut) => {
-  if (!!googleUser?.token && Date.now() < googleUser.expiresAt) {
-    return true;
-  }
-  handleSignOut();
-};

--- a/src/shared/utils/photos.js
+++ b/src/shared/utils/photos.js
@@ -48,7 +48,53 @@ export const getPhotosOnDate = async (_authToken, date, ranges, nextPageToken) =
   return { photos, error };
 };
 
+export const initMediaUpload = async ({ filename, mimeType, capturedAt }) => {
+  let data = null;
+  let error = null;
+
+  try {
+    const response = await fetch(`${LOCAL}/media`, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({
+        action: 'init-upload',
+        filename,
+        mimeType,
+        capturedAt,
+      }),
+    });
+    const result = await response.json();
+    if (response.ok && !result.error) {
+      data = result;
+    } else {
+      error = result.error || { code: response.status, message: 'Failed to init upload' };
+    }
+  } catch (err) {
+    error = err;
+  }
+
+  return { data, error };
+};
+
+export const uploadFileToPresignedUrl = async ({ uploadUrl, file, mimeType }) => {
+  let error = null;
+  try {
+    const response = await fetch(uploadUrl, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': mimeType || 'application/octet-stream',
+      },
+      body: file,
+    });
+    if (!response.ok) {
+      error = { code: response.status, message: 'Upload failed' };
+    }
+  } catch (err) {
+    error = err;
+  }
+  return { error };
+};
+
 export const photosSignIn = () => Promise.resolve('');
 
 export const photosVerifyToken = async () => true;
-

--- a/src/shared/utils/photos.js
+++ b/src/shared/utils/photos.js
@@ -13,7 +13,12 @@ const normalizeRanges = (ranges = []) =>
     end: r.end,
   }));
 
-export const getPhotosOnDate = async (_authToken, date, ranges, nextPageToken) => {
+export const getPhotosOnDate = async (
+  _authToken,
+  date,
+  ranges,
+  nextPageToken,
+) => {
   let photos = [];
   let error = null;
 
@@ -39,7 +44,10 @@ export const getPhotosOnDate = async (_authToken, date, ranges, nextPageToken) =
     if (response.ok && !result.error) {
       photos = result;
     } else {
-      error = result.error || { code: response.status, message: 'Failed to get media' };
+      error = result.error || {
+        code: response.status,
+        message: 'Failed to get media',
+      };
     }
   } catch (err) {
     error = err;
@@ -67,7 +75,10 @@ export const initMediaUpload = async ({ filename, mimeType, capturedAt }) => {
     if (response.ok && !result.error) {
       data = result;
     } else {
-      error = result.error || { code: response.status, message: 'Failed to init upload' };
+      error = result.error || {
+        code: response.status,
+        message: 'Failed to init upload',
+      };
     }
   } catch (err) {
     error = err;
@@ -76,7 +87,11 @@ export const initMediaUpload = async ({ filename, mimeType, capturedAt }) => {
   return { data, error };
 };
 
-export const uploadFileToPresignedUrl = async ({ uploadUrl, file, mimeType }) => {
+export const uploadFileToPresignedUrl = async ({
+  uploadUrl,
+  file,
+  mimeType,
+}) => {
   let error = null;
   try {
     const response = await fetch(uploadUrl, {


### PR DESCRIPTION
## Summary
This PR replaces the deprecated Google Photos integration with an S3-backed media flow for the diary app, including backend endpoints, frontend integration updates, and rollout/migration documentation.

## What changed
- Added a new authenticated backend `media` service:
  - `GET /media` to list media by date/MM-DD/ranges and return presigned read URLs.
  - `POST /media` with `action: "init-upload"` to return presigned upload URLs.
- Implemented S3 key strategy for DB-less lookup:
  - `media/mmdd=MM-DD/owner=<userId>/ts=<ISO8601>_<uuid>.<ext>`
- Wired S3 media service into app services registration.
- Replaced Google Photos API calls in frontend photo utilities with calls to local `/media` API.
- Updated photo-consuming UI surfaces to use the new flow:
  - Post photos panel
  - World map photo retrieval
  - Photos settings screen text to reflect S3 source
- Added S3 configuration entries:
  - bucket, region, prefix, presign TTLs
  - upload storage class support
- Set default media upload storage class to `GLACIER_IR` and configured the target bucket.
- Added rollout doc with API contract and migration steps from Google Takeout.
- Added AWS SDK dependencies for S3 and presigned URL support.

## Why these changes were made
Google Photos API access used by the diary feature is no longer viable, while the product requirement is to preserve the “photos for that day” experience with minimal ongoing cost and minimal operational complexity for two users. This PR moves media storage and retrieval to S3 and supports an architecture that works with shared bucket usage, on-demand reads, and future uploader clients.

## Important implementation details
- Backend `media` service is JWT-protected and uses AWS SDK v3.
- Read flow:
  - Lists S3 objects under `mmdd` prefix
  - Supports optional owner/range filtering
  - Sorts by timestamp embedded in key
  - Returns presigned `GET` URLs
- Upload flow:
  - `init-upload` creates deterministic key format and returns presigned `PUT` URL
  - Supports configurable `StorageClass` and now defaults to `GLACIER_IR`
- Configurability:
  - Supports environment/config overrides for bucket, region, endpoint, path-style mode, and storage class.
- Documentation:
  - Added `docs/s3-media-rollout.md` covering config, API usage, and migration/validation checklist.

This PR was written using [Vibe Kanban](https://vibekanban.com)
