### PR TITLE
Fix /last-time patch ID handling to avoid /last-time/0 updates (Vibe Kanban)

### DIFF
--- a/src/LastTime/index.tsx
+++ b/src/LastTime/index.tsx
@@ -20,6 +20,10 @@ import { dateToMySQLFormat } from '../shared/utils/mappers';
 import LastTimeEntry from './LastTimeEntry';
 import AddLastTime from './AddLastTime';
 
+type LastTimePatchPayload = {
+  id: number;
+} & Partial<Omit<LastTimeItemType, 'expired'>>;
+
 const LastTime = () => {
   const [isAdd, setIsAdd] = React.useState(false);
   const [isEdit, setIsEdit] = React.useState(false);
@@ -37,12 +41,10 @@ const LastTime = () => {
     queryFn: getLts,
   });
   const updateMutation = useUpdateMutation(
-    (values: LastTimeItemType) =>
-      editLT((itemToEdit || itemToUpdate)?.id || 0, values),
+    ({ id, ...values }: LastTimePatchPayload) => editLT(id, values),
     ['last_times'],
-    (itemToEdit || itemToUpdate)?.id,
-    (values: LastTimeItemType) => ({
-      ...(itemToEdit || itemToUpdate),
+    'id-from-payload',
+    (values: LastTimePatchPayload) => ({
       ...values,
     }),
     () => {
@@ -85,8 +87,17 @@ const LastTime = () => {
   const handleSubmit = (
     values: Omit<LastTimeItemType, 'expired' | 'id' | 'date'>,
   ) => {
-    const action = isAdd ? createMutation : updateMutation;
-    action.mutate(values);
+    if (isAdd) {
+      createMutation.mutate(values);
+      return;
+    }
+
+    const activeItem = itemToEdit || itemToUpdate;
+    if (!activeItem?.id) {
+      return;
+    }
+
+    updateMutation.mutate({ id: activeItem.id, ...values });
   };
 
   const handleClose = () => {
@@ -200,7 +211,13 @@ const LastTime = () => {
           <Grid>
             <Button
               onClick={() => {
-                updateMutation.mutate({ date: dateToMySQLFormat(updateDate) });
+                if (!itemToUpdate?.id) {
+                  return;
+                }
+                updateMutation.mutate({
+                  id: itemToUpdate.id,
+                  date: dateToMySQLFormat(updateDate),
+                });
               }}
             >
               OK


### PR DESCRIPTION
## Summary
This PR fixes `/last-time` updates that were sending patch requests with `id = 0`, causing edits to fail or target the wrong record.

## What Changed
- Refactored `LastTime` update mutation to require `id` in the mutation payload (`LastTimePatchPayload`) and call `editLT(id, values)` directly.
- Removed the fragile `((itemToEdit || itemToUpdate)?.id || 0)` fallback for patch requests.
- Updated optimistic cache matching in `useUpdateMutation` usage to use `'id-from-payload'`.
- Updated both update entry points to pass explicit IDs:
  - edit form submit flow
  - popover date update (`OK` button)
- Added guards to skip update mutation when no valid active item exists.

## Why
The `/last-time` feature had regressed: patch requests consistently used `0` as the id. The root cause was relying on transient UI state to derive the id at mutation time, with a `0` fallback. This change ensures each patch carries the target item id explicitly, making update behavior deterministic and preventing invalid `/last-time/0` requests.

## Implementation Details
- File changed: `src/LastTime/index.tsx`
- Introduced a local payload type:
  - `type LastTimePatchPayload = { id: number } & Partial<Omit<LastTimeItemType, 'expired'>>`
- `handleSubmit` now branches explicitly:
  - create mode: unchanged (`createMutation.mutate(values)`)
  - edit mode: resolves active item and sends `{ id, ...values }`
- Popover date patch now validates `itemToUpdate?.id` and sends `{ id, date }`.

This PR was written using [Vibe Kanban](https://vibekanban.com)
