### PR TITLE
Fix markdown toolbar contrast and hover states in dark theme (Vibe Kanban)

### DIFF
--- a/src/shared/components/MarkdownToolbar/index.tsx
+++ b/src/shared/components/MarkdownToolbar/index.tsx
@@ -161,13 +161,16 @@ const MarkdownToolbar = ({
           '& .MuiButton-root': {
             minWidth: 34,
             textTransform: 'none',
-            borderColor: (theme) => theme.palette.grey[300],
-            color: (theme) => theme.palette.text.secondary,
-            backgroundColor: (theme) => theme.palette.grey[100],
+            borderColor: (theme) => theme.palette.divider,
+            color: (theme) => theme.palette.text.primary,
+            backgroundColor: (theme) =>
+              theme.palette.mode === 'dark'
+                ? theme.palette.background.paper
+                : theme.palette.grey[50],
           },
           '& .MuiButton-root:hover': {
-            backgroundColor: (theme) => theme.palette.grey[200],
-            borderColor: (theme) => theme.palette.grey[300],
+            backgroundColor: (theme) => theme.palette.action.hover,
+            borderColor: (theme) => theme.palette.divider,
           },
         }}
       >


### PR DESCRIPTION
## Summary
This PR fixes dark-theme styling for the markdown editor toolbar used in post create/edit flows.

## What Changed
- Updated markdown toolbar button styles in `src/shared/components/MarkdownToolbar/index.tsx`.
- Replaced hardcoded light-gray border/background colors with theme-aware palette tokens.
- Switched button text color from `text.secondary` to `text.primary` for stronger readability in dark mode.
- Updated hover styles to use `action.hover` and `divider` so interaction states stay consistent across themes.
- Added mode-aware base background behavior:
  - Dark mode: `background.paper`
  - Light mode: `grey[50]`

## Why
The toolbar previously used fixed light grayscale values (`grey[100]`, `grey[200]`, `grey[300]`), which made controls look washed out and reduced contrast in dark theme. This change aligns the toolbar with the active MUI theme so the UI remains legible and visually consistent.

## Implementation Details
- The fix is scoped to style overrides on `.MuiButton-root` within the existing `ButtonGroup`.
- No toolbar behavior, formatting actions, or markdown transformation logic was changed.
- The update is token-based (palette-driven), making it resilient to future theme tuning.

This PR was written using [Vibe Kanban](https://vibekanban.com)
