### PR TITLE
Fix countdown calendar background rendering after deps upgrade (Vibe Kanban)

### DIFF
--- a/src/Countdown/index.tsx
+++ b/src/Countdown/index.tsx
@@ -16,7 +16,7 @@ import { useCreateMutation } from '../shared/hooks/useCreateMutation';
 import { useUpdateMutation } from '../shared/hooks/useUpdateMutation';
 import { useDeleteMutation } from '../shared/hooks/useDeleteMutation';
 import AddCountdown from './AddCountdown';
-import calendarIcon from './calendar.svg';
+import calendarIcon from './calendar.svg?no-inline';
 
 const Countdown = () => {
   const [countdownToEdit, setCountdownToEdit] =
@@ -96,6 +96,8 @@ const Countdown = () => {
               width: 300,
               height: 300,
               backgroundImage: `url(${calendarIcon})`,
+              backgroundRepeat: 'no-repeat',
+              backgroundPosition: 'center',
               backgroundSize: 'cover',
               color: (theme) => theme.palette.getContrastText('#fff'),
               cursor: 'pointer',


### PR DESCRIPTION
## Summary
This PR fixes the Countdown card visual regression where the yellow circular calendar background stopped rendering after the dependency upgrade.

## What Changed
- Updated the Countdown calendar asset import in `src/Countdown/index.tsx` from `./calendar.svg` to `./calendar.svg?no-inline`.
- Kept the existing `backgroundImage` usage, but added explicit background styling:
  - `backgroundRepeat: 'no-repeat'`
  - `backgroundPosition: 'center'`

## Why These Changes Were Made
After the major dependency/tooling upgrade, the Countdown calendar SVG started being inlined as a `data:` URI during bundling. In environments with stricter CSP handling, this can prevent the background from rendering, which removed the expected yellow circle + calendar visual from Countdown cards.

The fix forces Vite to emit the SVG as a file asset URL instead of an inlined data URI, restoring reliable rendering of the original UI.

## Implementation Details
- File changed: `src/Countdown/index.tsx`
- Net change: 1 import update and 2 style additions.
- Behavioral scope is intentionally narrow: this only affects Countdown card background asset loading and positioning, with no API/data-model changes.

This PR was written using [Vibe Kanban](https://vibekanban.com)
