### PR TITLE
Align PWA update toast theme with app settings (Vibe Kanban)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,14 +1,32 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { Button, Typography } from '@mui/material';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import App from './App';
+import { themeConfig } from './shared/config/theme';
+import { Theme } from './shared/types';
 import * as serviceWorkerRegistration from './serviceWorkerRegistration';
 import reportWebVitals from './reportWebVitals';
 
 const queryClient = new QueryClient();
-let hasRefreshedOnUpdate = false;
+
+const resolveThemeName = (): Theme.DARK | Theme.LIGHT => {
+  const cachedTheme = localStorage.getItem('theme_name');
+  const selectedTheme =
+    cachedTheme && Object.values(Theme).includes(cachedTheme as Theme)
+      ? (cachedTheme as Theme)
+      : Theme.SYSTEM;
+
+  if (selectedTheme === Theme.SYSTEM) {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+      ? Theme.DARK
+      : Theme.LIGHT;
+  }
+
+  return selectedTheme === Theme.DARK ? Theme.DARK : Theme.LIGHT;
+};
 
 const container = document.getElementById('root');
 const root = createRoot(container!);
@@ -26,29 +44,28 @@ serviceWorkerRegistration.register({
     const waitingServiceWorker = registration.waiting;
 
     if (waitingServiceWorker) {
+      waitingServiceWorker.addEventListener('statechange', (event) => {
+        const target = event.target as ServiceWorker | null;
+        if (target?.state === 'activated') {
+          window.location.reload();
+        }
+      });
       const messageNode = document.querySelector('#message');
       const handleClick = () => {
-        navigator.serviceWorker.addEventListener(
-          'controllerchange',
-          () => {
-            if (!hasRefreshedOnUpdate) {
-              hasRefreshedOnUpdate = true;
-              window.location.reload();
-            }
-          },
-          { once: true },
-        );
         waitingServiceWorker.postMessage({ type: 'SKIP_WAITING' });
       };
       if (messageNode) {
         const root = createRoot(messageNode);
+        const toastTheme = createTheme(themeConfig(resolveThemeName()));
         root.render(
-          <div>
-            <Typography>Update is available.</Typography>
-            <Button onClick={handleClick} variant="contained" fullWidth>
-              Reload
-            </Button>
-          </div>,
+          <ThemeProvider theme={toastTheme}>
+            <div>
+              <Typography>Update is available.</Typography>
+              <Button onClick={handleClick} variant="contained" fullWidth>
+                Reload
+              </Button>
+            </div>
+          </ThemeProvider>,
         );
         messageNode.className = 'root-message';
       }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { CssBaseline, Button, Typography, ThemeProvider } from '@mui/material';
+import { Button, Typography } from '@mui/material';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import App from './App';
-import theme from './shared/config/theme';
 import * as serviceWorkerRegistration from './serviceWorkerRegistration';
 import reportWebVitals from './reportWebVitals';
 
 const queryClient = new QueryClient();
+let hasRefreshedOnUpdate = false;
 
 const container = document.getElementById('root');
 const root = createRoot(container!);
@@ -26,28 +26,29 @@ serviceWorkerRegistration.register({
     const waitingServiceWorker = registration.waiting;
 
     if (waitingServiceWorker) {
-      waitingServiceWorker.addEventListener('statechange', (event) => {
-        // @ts-ignore
-        if (event.target && event.target.state === 'activated') {
-          window.location.reload();
-        }
-      });
       const messageNode = document.querySelector('#message');
       const handleClick = () => {
+        navigator.serviceWorker.addEventListener(
+          'controllerchange',
+          () => {
+            if (!hasRefreshedOnUpdate) {
+              hasRefreshedOnUpdate = true;
+              window.location.reload();
+            }
+          },
+          { once: true },
+        );
         waitingServiceWorker.postMessage({ type: 'SKIP_WAITING' });
       };
       if (messageNode) {
         const root = createRoot(messageNode);
         root.render(
-          <ThemeProvider theme={theme}>
-            <CssBaseline />
-            <div>
-              <Typography>Update is available.</Typography>
-              <Button onClick={handleClick} variant="contained" fullWidth>
-                Reload
-              </Button>
-            </div>
-          </ThemeProvider>,
+          <div>
+            <Typography>Update is available.</Typography>
+            <Button onClick={handleClick} variant="contained" fullWidth>
+              Reload
+            </Button>
+          </div>,
         );
         messageNode.className = 'root-message';
       }


### PR DESCRIPTION
## Summary
This PR updates the PWA update notification rendering so the "Update is available" toast uses the same theme mode as the rest of the app.

## What Changed
- Updated `src/index.tsx` to resolve the active theme mode (`light`/`dark`) from the same source used by the app (`theme_name` in local storage, with system preference fallback).
- Created a dedicated toast theme via `createTheme(themeConfig(resolveThemeName()))` and wrapped the update toast with `ThemeProvider` using that resolved theme.
- Removed `CssBaseline` from the toast render path to avoid global baseline style injection from the toast mount point.
- Replaced the `@ts-ignore` in the service worker `statechange` handler with a typed cast (`ServiceWorker | null`) for safer type handling.

## Why
The task context was a visual regression during PWA update flow: when the frontend showed "Update is available" and the user reloaded, styles appeared broken and the background became black instead of expected app styling. The update toast was using its own baseline-influencing styling path, which could conflict with global page styles.

## Important Implementation Details
- Service worker behavior was intentionally kept unchanged (same `waiting` worker + `SKIP_WAITING` + reload-on-`activated` flow).
- The fix is isolated to toast theming and type-safety in `src/index.tsx`; no service worker file logic was altered.
- Theme resolution mirrors app behavior by honoring explicit user selection first, then `prefers-color-scheme` when theme is `system`.

This PR was written using [Vibe Kanban](https://vibekanban.com)
