### PR TITLE
Fix stale edit IDs across frontend update flows (Vibe Kanban)

### DIFF
--- a/src/Countdown/index.tsx
+++ b/src/Countdown/index.tsx
@@ -18,6 +18,10 @@ import { useDeleteMutation } from '../shared/hooks/useDeleteMutation';
 import AddCountdown from './AddCountdown';
 import calendarIcon from './calendar.svg?no-inline';
 
+type CountdownPatchPayload = {
+  id: number;
+} & Omit<CountdownType, 'id' | 'created_at' | 'user_id' | 'is_done'>;
+
 const Countdown = () => {
   const [countdownToEdit, setCountdownToEdit] =
     React.useState<CountdownType | null>(null);
@@ -37,10 +41,10 @@ const Countdown = () => {
     },
   );
   const editMutation = useUpdateMutation(
-    (values: CountdownType) => editCountdown(countdownToEdit?.id || 0, values),
+    ({ id, ...values }: CountdownPatchPayload) => editCountdown(id, values),
     ['countdown'],
-    countdownToEdit?.id,
-    (values: CountdownType) => values,
+    'id-from-payload',
+    ({ id, ...values }: CountdownPatchPayload) => ({ id, ...values }),
     () => {
       setIsEdit(false);
       setCountdownToEdit(null);
@@ -57,9 +61,14 @@ const Countdown = () => {
   ) => {
     if (isAdd) {
       addMutation.mutate(values);
-    } else {
-      editMutation.mutate(values);
+      return;
     }
+
+    if (!countdownToEdit?.id) {
+      return;
+    }
+
+    editMutation.mutate({ id: countdownToEdit.id, ...values });
   };
 
   const handleEditClick = (

--- a/src/Days/Settings/LabelsSettings/index.tsx
+++ b/src/Days/Settings/LabelsSettings/index.tsx
@@ -24,6 +24,14 @@ import { useDeleteMutation } from '../../../shared/hooks/useDeleteMutation';
 import { useCreateMutation } from '../../../shared/hooks/useCreateMutation';
 import { LabelType } from '../../../shared/types';
 
+type LabelPatchPayload = {
+  id: number;
+  name: string;
+  color: string;
+  color_active: string;
+  emoji: string | null;
+};
+
 const LabelsSettings = () => {
   const [activeLabels, setActiveLabels] = React.useState<number[]>([]);
   const [anchorEl, setAnchorEl] = React.useState<HTMLDivElement | null>(null);
@@ -43,21 +51,10 @@ const LabelsSettings = () => {
   });
 
   const editLabelMutation = useUpdateMutation(
-    () =>
-      putLabel(labelToEdit || 0, {
-        name: newLabelName,
-        color: newLabelColor[0],
-        color_active: newLabelColor[1],
-        emoji: newLabelEmoji || null,
-      }),
+    ({ id, ...values }: LabelPatchPayload) => putLabel(id, values),
     ['labels'],
-    labelToEdit,
-    () => ({
-      name: newLabelName,
-      color: newLabelColor[0],
-      color_active: newLabelColor[1],
-      emoji: newLabelEmoji || null,
-    }),
+    'id-from-payload',
+    ({ id, ...values }: LabelPatchPayload) => ({ id, ...values }),
     () => {
       setIsEdit(false);
       setNewLabelName('');
@@ -108,7 +105,16 @@ const LabelsSettings = () => {
 
   const handleLabelEdit = (e: FormEvent) => {
     e.preventDefault();
-    editLabelMutation.mutate('');
+    if (!labelToEdit) {
+      return;
+    }
+    editLabelMutation.mutate({
+      id: labelToEdit,
+      name: newLabelName,
+      color: newLabelColor[0],
+      color_active: newLabelColor[1],
+      emoji: newLabelEmoji || null,
+    });
   };
 
   const handleLabelAdd = (e: FormEvent) => {

--- a/src/NoteShow/index.tsx
+++ b/src/NoteShow/index.tsx
@@ -11,6 +11,10 @@ import { deleteNote, getNotes, postNote, editNote } from '../shared/api/routes';
 import { NoteType } from '../shared/types';
 import AddNote from './AddNote';
 
+type NotePatchPayload = {
+  id: number;
+} & Omit<NoteType, 'id' | 'note_category' | 'created_at' | 'updated_at'>;
+
 const formatDate = (dateString: string) => {
   const date = new Date(dateString);
   return date.toLocaleDateString('en-US', {
@@ -32,10 +36,10 @@ const NoteCategoryShow = () => {
     queryFn: () => getNotes(params.id || 0),
   });
   const editMutation = useUpdateMutation(
-    (vals: Omit<NoteType, 'id'>) => editNote(noteToEdit?.id || 0, vals),
+    ({ id, ...vals }: NotePatchPayload) => editNote(id, vals),
     ['notes', params.id],
-    noteToEdit?.id,
-    (val: NoteType) => val,
+    'id-from-payload',
+    ({ id, ...vals }: NotePatchPayload) => ({ id, ...vals }),
     () => {
       setNoteToEdit(null);
     },
@@ -67,9 +71,14 @@ const NoteCategoryShow = () => {
   ) => {
     if (isAdd) {
       addMutation.mutate(values);
-    } else {
-      editMutation.mutate(values);
+      return;
     }
+
+    if (!noteToEdit?.id) {
+      return;
+    }
+
+    editMutation.mutate({ id: noteToEdit.id, ...values });
   };
 
   const handleCancel = () => {

--- a/src/Notes/index.tsx
+++ b/src/Notes/index.tsx
@@ -30,6 +30,10 @@ import { useDeleteMutation } from '../shared/hooks/useDeleteMutation';
 import { NoteCategoryType } from '../shared/types';
 import AddNoteCategory from './AddNoteCategory';
 
+type NoteCategoryPatchPayload = {
+  id: number;
+} & Omit<NoteCategoryType, 'id'>;
+
 const NoteCategories = () => {
   const [isAdd, setIsAdd] = React.useState(false);
   const [noteCategoryToEdit, setNoteCategoryToEdit] =
@@ -52,11 +56,10 @@ const NoteCategories = () => {
     },
   );
   const editMutation = useUpdateMutation(
-    (vals: NoteCategoryType) =>
-      putNoteCategory(noteCategoryToEdit?.id || 0, vals),
+    ({ id, ...vals }: NoteCategoryPatchPayload) => putNoteCategory(id, vals),
     ['note_categories'],
-    noteCategoryToEdit?.id,
-    (vals: NoteCategoryType) => vals,
+    'id-from-payload',
+    ({ id, ...vals }: NoteCategoryPatchPayload) => ({ id, ...vals }),
     () => {
       setNoteCategoryToEdit(null);
     },
@@ -78,9 +81,14 @@ const NoteCategories = () => {
   const handleSubmit = (values: Omit<NoteCategoryType, 'note_count'>) => {
     if (isAdd) {
       addMutation.mutate({ name: values.name });
-    } else {
-      editMutation.mutate(values);
+      return;
     }
+
+    if (!noteCategoryToEdit?.id) {
+      return;
+    }
+
+    editMutation.mutate({ id: noteCategoryToEdit.id, name: values.name });
   };
 
   const handleEditClick = (

--- a/src/Projects/index.tsx
+++ b/src/Projects/index.tsx
@@ -18,6 +18,10 @@ import { useUpdateMutation } from '../shared/hooks/useUpdateMutation';
 import { ProjectType } from '../shared/types';
 import AddProject from './AddProject';
 
+type ProjectPatchPayload = {
+  id: number;
+} & Omit<ProjectType, 'id' | 'created_at'>;
+
 const Projects = () => {
   const [projectToEdit, setProjectToEdit] = React.useState<ProjectType | null>(
     null,
@@ -38,10 +42,10 @@ const Projects = () => {
     },
   );
   const editMutation = useUpdateMutation(
-    (values: ProjectType) => putProject(projectToEdit?.id || 0, values),
+    ({ id, ...values }: ProjectPatchPayload) => putProject(id, values),
     ['projects'],
-    projectToEdit?.id,
-    (values: ProjectType) => values,
+    'id-from-payload',
+    ({ id, ...values }: ProjectPatchPayload) => ({ id, ...values }),
     () => {
       setIsEdit(false);
       setProjectToEdit(null);
@@ -52,9 +56,14 @@ const Projects = () => {
   const handleSubmit = (values: Omit<ProjectType, 'id' | 'created_at'>) => {
     if (isAdd) {
       addMutation.mutate(values);
-    } else {
-      editMutation.mutate(values);
+      return;
     }
+
+    if (!projectToEdit?.id) {
+      return;
+    }
+
+    editMutation.mutate({ id: projectToEdit.id, ...values });
   };
 
   const handleEditClick = (

--- a/src/Transactions/TransactionsCategories/index.tsx
+++ b/src/Transactions/TransactionsCategories/index.tsx
@@ -29,6 +29,10 @@ import { useUpdateMutation } from '../../shared/hooks/useUpdateMutation';
 import { useDeleteMutation } from '../../shared/hooks/useDeleteMutation';
 import TransactionsCategoriesCreate from './AddCategory';
 
+type TransactionCategoryPatchPayload = {
+  id: number;
+} & Omit<TransactionCategoryType, 'id'>;
+
 const TransactionsCategories = () => {
   const [categoryToEdit, setCategoryToEdit] =
     React.useState<TransactionCategoryType | null>(null);
@@ -52,11 +56,11 @@ const TransactionsCategories = () => {
     },
   );
   const editMutation = useUpdateMutation(
-    (values: TransactionCategoryType) =>
-      patchTransactionCategory(categoryToEdit?.id || 0, values),
+    ({ id, ...values }: TransactionCategoryPatchPayload) =>
+      patchTransactionCategory(id, values),
     ['transactions_categories'],
-    categoryToEdit?.id,
-    (values: TransactionCategoryType) => values,
+    'id-from-payload',
+    ({ id, ...values }: TransactionCategoryPatchPayload) => ({ id, ...values }),
     () => {
       setIsEdit(false);
       setIsEdit(false);
@@ -75,9 +79,14 @@ const TransactionsCategories = () => {
   const handleSubmit = (name: string) => {
     if (isAdd) {
       addMutation.mutate(name);
-    } else {
-      editMutation.mutate({ name });
+      return;
     }
+
+    if (!categoryToEdit?.id) {
+      return;
+    }
+
+    editMutation.mutate({ id: categoryToEdit.id, name });
   };
 
   const handleEditClick = (

--- a/src/Watch/index.tsx
+++ b/src/Watch/index.tsx
@@ -32,6 +32,10 @@ import { dateToMySQLFormat } from '../shared/utils/mappers';
 import WatchEntry from './WatchEntry';
 import AddWatch from './AddWatch';
 
+type WatchPatchPayload = {
+  id: number;
+} & Partial<Omit<WatchItemType, 'id' | 'created_at'>>;
+
 const Watch = () => {
   const [isAdd, setIsAdd] = React.useState(false);
   const [isEdit, setIsEdit] = React.useState(false);
@@ -66,12 +70,12 @@ const Watch = () => {
     },
   });
   const updateMutation = useUpdateMutation(
-    (values: WatchItemType) =>
-      editWatch((itemToEdit || itemToUpdate)?.id || 0, values),
+    ({ id, ...values }: WatchPatchPayload) => editWatch(id, values),
     ['watch', { filterType, filterSeen, sortBy, sortDir }],
-    (itemToEdit || itemToUpdate)?.id,
-    (values: WatchItemType) => ({
-      ...(itemToEdit || itemToUpdate),
+    'id-from-payload',
+    ({ id, ...values }: WatchPatchPayload, item: WatchItemType) => ({
+      ...item,
+      id,
       ...values,
     }),
     () => {
@@ -112,8 +116,17 @@ const Watch = () => {
   const handleSubmit = (
     values: Omit<WatchItemType, 'last_seen' | 'id' | 'created_at'>,
   ) => {
-    const action = isAdd ? createMutation : updateMutation;
-    action.mutate(values);
+    if (isAdd) {
+      createMutation.mutate(values);
+      return;
+    }
+
+    const activeItem = itemToEdit || itemToUpdate;
+    if (!activeItem?.id) {
+      return;
+    }
+
+    updateMutation.mutate({ id: activeItem.id, ...values });
   };
 
   const handleClose = () => {
@@ -265,7 +278,11 @@ const Watch = () => {
           <Grid>
             <Button
               onClick={() => {
+                if (!itemToUpdate?.id) {
+                  return;
+                }
                 updateMutation.mutate({
+                  id: itemToUpdate.id,
                   last_seen: dateToMySQLFormat(updateDate),
                 });
               }}


### PR DESCRIPTION
## Summary
This PR fixes frontend edit flows that could send `id: 0` after the recent dependency upgrade, which caused update requests to target invalid records (for example, project editing).

## What Changed
- Updated edit flows to pass the entity id in the mutation payload (`{ id, ...changes }`) instead of reading id from potentially stale component state.
- Aligned affected screens with the same pattern already used in `/last-time`.
- Added guards before edit mutations to avoid sending update requests when no valid item id is selected.

Updated files:
- `src/Projects/index.tsx`
- `src/Countdown/index.tsx`
- `src/NoteShow/index.tsx`
- `src/Notes/index.tsx`
- `src/Watch/index.tsx`
- `src/Transactions/TransactionsCategories/index.tsx`
- `src/Days/Settings/LabelsSettings/index.tsx`

## Why
The task context identified a regression after the major dependency upgrade: some edit actions were sending id `0` from the frontend. This happened because mutation functions depended on closure state values like `itemToEdit?.id || 0`, which can be stale at mutation time.

## Implementation Details
- Switched `useUpdateMutation` usage in affected modules to the payload-id pattern:
  - `mutationFn`: `({ id, ...values }) => apiUpdate(id, values)`
  - optimistic id source: `'id-from-payload'`
  - optimistic item merge includes payload data, including id.
- Updated submit/click handlers to build and send explicit payloads with id.
- Preserved existing query invalidation behavior and UI reset callbacks.

This PR was written using [Vibe Kanban](https://vibekanban.com)
