### PR TITLE
Improve post media upload and fullscreen preview navigation (Vibe Kanban)

### DIFF
--- a/src/Days/PostShow/PostPhotos/index.tsx
+++ b/src/Days/PostShow/PostPhotos/index.tsx
@@ -264,6 +264,12 @@ const PostPhotos = ({
       <Dialog
         open={previewIndex !== null}
         onClose={() => setPreviewIndex(null)}
+        fullScreen
+        PaperProps={{
+          sx: {
+            backgroundColor: 'rgba(0, 0, 0, 0.85)',
+          },
+        }}
       >
         <Box
           sx={{
@@ -271,20 +277,26 @@ const PostPhotos = ({
             display: 'flex',
             alignItems: 'center',
             justifyContent: 'center',
-            minWidth: { xs: '80vw', sm: '70vw' },
-            minHeight: { xs: '50vh', sm: '70vh' },
-            backgroundColor: 'black',
+            width: '100vw',
+            height: '100vh',
           }}
         >
           {photos.length > 1 ? (
             <Button
               onClick={showPreviousMedia}
               sx={{
-                position: 'absolute',
-                left: 8,
+                position: 'fixed',
+                left: 0,
+                top: 0,
+                bottom: 0,
+                borderRadius: 0,
+                width: { xs: 56, sm: 80 },
                 minWidth: 0,
                 color: '#fff',
                 zIndex: 1,
+                '&:hover': {
+                  backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                },
               }}
               aria-label="Previous file"
             >
@@ -298,16 +310,17 @@ const PostPhotos = ({
                 controls
                 autoPlay
                 style={{
-                  maxWidth: '90vw',
-                  maxHeight: '90vh',
+                  maxWidth: 'calc(100vw - 160px)',
+                  maxHeight: '95vh',
                 }}
               />
             ) : (
               <img
                 src={previewMedia.baseUrl}
                 style={{
-                  maxWidth: '90vw',
-                  maxHeight: '90vh',
+                  maxWidth: 'calc(100vw - 160px)',
+                  maxHeight: '95vh',
+                  objectFit: 'contain',
                 }}
                 alt={date.toString()}
               />
@@ -317,11 +330,18 @@ const PostPhotos = ({
             <Button
               onClick={showNextMedia}
               sx={{
-                position: 'absolute',
-                right: 8,
+                position: 'fixed',
+                right: 0,
+                top: 0,
+                bottom: 0,
+                borderRadius: 0,
+                width: { xs: 56, sm: 80 },
                 minWidth: 0,
                 color: '#fff',
                 zIndex: 1,
+                '&:hover': {
+                  backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                },
               }}
               aria-label="Next file"
             >


### PR DESCRIPTION
## Summary
This PR improves the post media experience by adding bulk upload support, better in-gallery navigation, clearer video thumbnails, and a full-screen preview layout fix so controls no longer overlap content.

## What Changed
- Updated `PostPhotos` to handle multi-file uploads for photos and videos in one selection.
- Switched upload handling to per-file async tasks with `Promise.allSettled(...)` to process all selected files and still refresh media after partial success.
- Reworked preview state from a single media object to index-based navigation (`previewIndex`) so users can move through all files for a post.
- Added keyboard navigation in preview mode:
  - `ArrowLeft` for previous file
  - `ArrowRight` for next file
- Added on-screen previous/next chevron controls.
- Added a play icon overlay on video thumbnails to clearly distinguish videos from images.
- Updated CTA text from `UPLOAD PHOTO` to `UPLOAD FILES`.
- Fixed preview layout by making the dialog full-screen and moving navigation arrows to the left/right backdrop edges (instead of consuming media space inside the content area).

## Why
The task required improving the photos section UX by:
- allowing bulk uploads for photos/videos,
- enabling easier file-to-file navigation with both keyboard and clickable controls,
- making videos visually identifiable in the grid,
- and correcting the preview layout regression where arrows reduced visible media area.

These updates reduce upload friction, speed up browsing through post media, and improve visual clarity and usability on large previews.

## Implementation Details
- File changed: `src/Days/PostShow/PostPhotos/index.tsx`
- Navigation behavior is cyclic (wraps around at the beginning/end of the list).
- Keyboard listeners are attached only while preview is open and cleaned up on close.
- Thumbnail video detection continues to rely on extension-based `isVideoMedia(...)` checks.
- Preview dialog now uses `fullScreen` with a dimmed backdrop and fixed edge controls:
  - left arrow pinned to the left backdrop edge
  - right arrow pinned to the right backdrop edge
- Media is constrained with `objectFit: contain` and `maxWidth/maxHeight` so content remains centered and visible.

This PR was written using [Vibe Kanban](https://vibekanban.com)
