### PR TITLE
Migrate diary media to S3 with resilient Takeout import and dedupe-ready upload flow (Vibe Kanban)

### DIFF
--- a/docs/mobile-auto-upload-dedupe-plan.md
+++ b/docs/mobile-auto-upload-dedupe-plan.md
@@ -1,0 +1,124 @@
+# Mobile Auto Upload Plan (Android + S3, TS Keys, No DB)
+
+## Goal
+- Build Android auto-upload similar to Google Photos behavior.
+- Keep existing migrated S3 key format based on timestamp/date.
+- Add duplicate detection without introducing a database.
+
+## Constraints
+- Shared S3 bucket for 2 users.
+- Existing migrated objects already use `ts` key naming.
+- Backend remains stateless; persistence lives in S3 objects.
+
+## Current Key Strategy (Keep As-Is)
+- Media object key:
+  - `media/date=YYYY-MM-DD/owner=<ownerId>/ts=<ISO8601>_<uuid>.<ext>`
+- Do not rename already migrated objects.
+- Do not require hash-in-key for new uploads.
+
+## Dedupe Strategy (New)
+- Use S3-based dedupe index objects keyed by SHA-256:
+  - `media-index/v1/owner=<ownerId>/sha256/<first2>/<sha256>.json`
+- Dedupe marker payload:
+```json
+{
+  "sha256": "hex",
+  "sizeBytes": 1234567,
+  "mimeType": "image/jpeg",
+  "canonicalMediaKey": "media/date=2026-04-07/owner=1/ts=2026-04-07T10:12:03Z_x.jpg",
+  "createdAt": "2026-04-07T10:12:20Z",
+  "source": "android|takeout|web",
+  "owner": "1"
+}
+```
+- Duplicate rule:
+  - Primary: exact `sha256`.
+  - Optional safety check: `sizeBytes` must match marker value.
+
+## Backend API Contract (v1)
+- `POST /media` action: `init-upload`
+  - Input: `owner`, `filename`, `contentType`, `sizeBytes`, `capturedAt`, `sha256`
+  - Behavior:
+    - Check dedupe marker by owner + sha256.
+    - If marker exists: return `{ duplicate: true, existingKey }`.
+    - If not: return `{ duplicate: false, uploadUrl, key, method: "PUT" }`.
+- `POST /media` action: `complete-upload`
+  - Input: `key`, `owner`, `sha256`, `sizeBytes`, `contentType`, `capturedAt`
+  - Behavior:
+    - Verify object exists.
+    - Write dedupe marker (idempotent put).
+    - Return success.
+- `POST /media` action: `fail-upload` (optional)
+  - Input: `key`, `reason`.
+  - Behavior: log only (no state mutation required).
+
+## Android App Plan
+- Stack: native Android (Kotlin), WorkManager, Room.
+- Discovery:
+  - MediaStore initial scan.
+  - ContentObserver for new items.
+- Upload queue item fields:
+  - `localUri`, `size`, `mime`, `dateTaken`, `sha256`, `status`, `attempts`, `lastError`.
+- Upload flow:
+  1. Read file metadata from MediaStore.
+  2. Compute SHA-256 (streaming).
+  3. Call `init-upload`.
+  4. If duplicate: mark synced locally.
+  5. Else PUT file to presigned URL.
+  6. Call `complete-upload`.
+  7. Mark synced locally.
+- Background behavior:
+  - WorkManager periodic + one-time work.
+  - Constraints: network required; optional wifi/charging toggles.
+  - Foreground service for large batches/videos.
+
+## Migration Awareness Plan
+- One-time S3 backfill job for migrated media:
+  1. List `media/date=*/owner=*/ts=*`.
+  2. Stream object, compute SHA-256.
+  3. Write dedupe marker if missing.
+- Result:
+  - Android app can immediately detect duplicates against migrated content.
+
+## Idempotency + Concurrency Rules
+- `init-upload` can be called repeatedly for same file.
+- `complete-upload` must be idempotent.
+- Dedupe marker write should be "first writer wins", same canonical key acceptable.
+- If duplicate marker appears between init and complete:
+  - Keep uploaded object or schedule cleanup job; do not fail user flow.
+
+## Security
+- Auth required on all `/media` actions.
+- Owner isolation in index paths and media prefixes.
+- Presigned upload URL TTL: short (e.g., 10 minutes).
+- Validate `contentType` and max file size before URL issuance.
+
+## Observability
+- Structured logs for:
+  - init duplicate hit/miss,
+  - upload complete,
+  - marker write success/fail,
+  - android retry causes.
+- Counters:
+  - uploads attempted/succeeded,
+  - duplicate skips,
+  - average upload duration.
+
+## Rollout Phases
+- Phase 1: Backend dedupe contract + index writer.
+- Phase 2: Backfill hashes for migrated objects.
+- Phase 3: Android MVP uploader (manual trigger + background worker).
+- Phase 4: Auto-detect + reliability tuning (battery/network constraints).
+
+## First Implementation Checklist
+- Add backend actions:
+  - `init-upload`, `complete-upload`.
+- Add helper in server media service:
+  - `getDedupeMarker(owner, sha256)`, `putDedupeMarker(...)`.
+- Add script:
+  - `scripts/backfill-s3-hash-index.js`.
+- Add Android app skeleton repo/module:
+  - MediaStore scan,
+  - SHA-256 utility,
+  - upload worker + queue storage.
+

--- a/scripts/backfill-s3-hash-index.js
+++ b/scripts/backfill-s3-hash-index.js
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+
+/* eslint-disable no-console */
+const crypto = require('crypto');
+const {
+  GetObjectCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  S3Client,
+} = require('@aws-sdk/client-s3');
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i += 1) {
+    const part = argv[i];
+    if (!part.startsWith('--')) continue;
+    const key = part.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      args[key] = true;
+      continue;
+    }
+    args[key] = next;
+    i += 1;
+  }
+  return args;
+}
+
+function requireArg(args, key, fallback) {
+  const value = args[key] || fallback;
+  if (!value) throw new Error(`Missing required --${key}`);
+  return value;
+}
+
+function normalizePrefix(value, withTrailingSlash = true) {
+  let out = String(value || '').replace(/^\/+/, '');
+  if (withTrailingSlash && out && !out.endsWith('/')) out += '/';
+  return out;
+}
+
+function isMediaKey(key) {
+  const lower = key.toLowerCase();
+  if (lower.endsWith('.metadata.json')) return false;
+  return [
+    '.jpg',
+    '.jpeg',
+    '.png',
+    '.gif',
+    '.webp',
+    '.heic',
+    '.heif',
+    '.avif',
+    '.mp4',
+    '.mov',
+    '.avi',
+    '.m4v',
+    '.3gp',
+    '.mkv',
+    '.webm',
+  ].some((ext) => lower.endsWith(ext));
+}
+
+function ownerFromKey(key) {
+  const m = key.match(/\/owner=([^/]+)\//);
+  return m?.[1] || 'unknown';
+}
+
+function dedupeKey(indexPrefix, owner, sha256) {
+  const shard = sha256.slice(0, 2);
+  return `${indexPrefix}owner=${owner}/sha256/${shard}/${sha256}.json`;
+}
+
+async function sha256FromObjectBody(body) {
+  const hash = crypto.createHash('sha256');
+  for await (const chunk of body) {
+    hash.update(chunk);
+  }
+  return hash.digest('hex');
+}
+
+async function markerExists(s3, bucket, key) {
+  try {
+    await s3.send(
+      new HeadObjectCommand({
+        Bucket: bucket,
+        Key: key,
+      }),
+    );
+    return true;
+  } catch (error) {
+    const status = Number(error?.$metadata?.httpStatusCode || 0);
+    return status !== 404;
+  }
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const bucket = requireArg(args, 'bucket', process.env.AWS_S3_BUCKET);
+  const region = args.region || process.env.AWS_REGION || 'us-east-1';
+  const mediaPrefix = normalizePrefix(args.mediaPrefix || 'media/');
+  const indexPrefix = normalizePrefix(args.indexPrefix || 'media-index/v1/');
+  const dryRun = Boolean(args.dryRun);
+  const limit = Number(args.limit || 0) || 0;
+
+  const s3 = new S3Client({
+    region,
+    endpoint: args.endpoint || process.env.AWS_S3_ENDPOINT || undefined,
+    forcePathStyle: Boolean(
+      args.forcePathStyle || process.env.AWS_S3_FORCE_PATH_STYLE === 'true',
+    ),
+  });
+
+  let continuationToken = undefined;
+  let scanned = 0;
+  let mediaCount = 0;
+  let indexed = 0;
+  let skippedExisting = 0;
+  let failed = 0;
+
+  while (true) {
+    const page = await s3.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        Prefix: mediaPrefix,
+        ContinuationToken: continuationToken,
+        MaxKeys: 1000,
+      }),
+    );
+
+    for (const obj of page.Contents || []) {
+      const key = obj.Key;
+      scanned += 1;
+      if (!key || !isMediaKey(key)) continue;
+      mediaCount += 1;
+      if (limit > 0 && mediaCount > limit) break;
+
+      try {
+        const getResp = await s3.send(
+          new GetObjectCommand({
+            Bucket: bucket,
+            Key: key,
+          }),
+        );
+        if (!getResp.Body) {
+          failed += 1;
+          console.error(`Failed (no body): ${key}`);
+          continue;
+        }
+
+        const sha256 = await sha256FromObjectBody(getResp.Body);
+        const owner = ownerFromKey(key);
+        const indexKey = dedupeKey(indexPrefix, owner, sha256);
+        const exists = await markerExists(s3, bucket, indexKey);
+        if (exists) {
+          skippedExisting += 1;
+          continue;
+        }
+
+        const payload = {
+          sha256,
+          sizeBytes: Number(obj.Size || 0),
+          canonicalMediaKey: key,
+          createdAt: new Date().toISOString(),
+          source: 'takeout-backfill',
+          owner,
+        };
+
+        if (!dryRun) {
+          await s3.send(
+            new PutObjectCommand({
+              Bucket: bucket,
+              Key: indexKey,
+              ContentType: 'application/json',
+              Body: JSON.stringify(payload),
+            }),
+          );
+        }
+
+        indexed += 1;
+        console.log(
+          `${dryRun ? '[DRY] ' : ''}Indexed ${key} -> ${indexKey}`,
+        );
+      } catch (error) {
+        failed += 1;
+        console.error(`Failed: ${key} (${error.message})`);
+      }
+    }
+
+    if ((limit > 0 && mediaCount >= limit) || !page.IsTruncated) {
+      break;
+    }
+    continuationToken = page.NextContinuationToken;
+  }
+
+  console.log('Done.');
+  console.log(`Scanned objects: ${scanned}`);
+  console.log(`Media objects: ${mediaCount}`);
+  console.log(`Indexed markers: ${indexed}`);
+  console.log(`Skipped existing: ${skippedExisting}`);
+  console.log(`Failed: ${failed}`);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});
+

--- a/server/services/media/media.class.ts
+++ b/server/services/media/media.class.ts
@@ -4,6 +4,7 @@ import { BadRequest, GeneralError } from '@feathersjs/errors';
 import {
   DeleteObjectCommand,
   GetObjectCommand,
+  HeadObjectCommand,
   ListObjectsV2Command,
   PutObjectCommand,
   S3Client,
@@ -28,11 +29,15 @@ type MediaQuery = {
 };
 
 type UploadInitBody = {
-  action: 'init-upload';
+  action: 'init-upload' | 'complete-upload' | 'fail-upload';
   filename: string;
   mimeType?: string;
   capturedAt?: string;
   owner?: string;
+  sha256?: string;
+  sizeBytes?: number;
+  key?: string;
+  reason?: string;
 };
 
 type MediaRange = {
@@ -121,6 +126,7 @@ export class MediaService {
   getUrlTtlSeconds: number;
   putUrlTtlSeconds: number;
   uploadStorageClass?: StorageClass;
+  dedupeIndexPrefix: string;
 
   constructor(app: Application) {
     this.app = app;
@@ -142,6 +148,12 @@ export class MediaService {
     if (!this.prefix.endsWith('/')) {
       this.prefix += '/';
     }
+    this.dedupeIndexPrefix = String(
+      cfg.dedupeIndexPrefix || 'media-index/v1/',
+    ).replace(/^\/+/, '');
+    if (!this.dedupeIndexPrefix.endsWith('/')) {
+      this.dedupeIndexPrefix += '/';
+    }
     this.s3 = new S3Client({
       region: cfg.region || process.env.AWS_REGION || 'us-east-1',
       endpoint: cfg.endpoint || process.env.AWS_S3_ENDPOINT || undefined,
@@ -149,6 +161,84 @@ export class MediaService {
         cfg.forcePathStyle || process.env.AWS_S3_FORCE_PATH_STYLE === 'true',
       ),
     });
+  }
+
+  buildDedupeKey(owner: string, sha256: string) {
+    const shard = sha256.slice(0, 2);
+    return `${this.dedupeIndexPrefix}owner=${owner}/sha256/${shard}/${sha256}.json`;
+  }
+
+  normalizeSha256(value?: string) {
+    if (!value) return null;
+    const normalized = value.trim().toLowerCase();
+    if (!/^[a-f0-9]{64}$/.test(normalized)) {
+      throw new BadRequest('sha256 must be a 64-character hex string');
+    }
+    return normalized;
+  }
+
+  async getDedupeMarker(owner: string, sha256?: string) {
+    const normalized = this.normalizeSha256(sha256);
+    if (!normalized) return null;
+
+    const key = this.buildDedupeKey(owner, normalized);
+    try {
+      const result = await this.s3.send(
+        new GetObjectCommand({
+          Bucket: this.bucket,
+          Key: key,
+        }),
+      );
+      const body = await result.Body?.transformToString();
+      if (!body) return null;
+      return JSON.parse(body);
+    } catch (error: any) {
+      const status = Number(error?.$metadata?.httpStatusCode || 0);
+      if (status === 404 || error?.name === 'NoSuchKey') {
+        return null;
+      }
+      throw new GeneralError('Failed to read dedupe marker', { error });
+    }
+  }
+
+  async putDedupeMarker({
+    owner,
+    sha256,
+    sizeBytes,
+    mimeType,
+    key,
+    source,
+  }: {
+    owner: string;
+    sha256: string;
+    sizeBytes?: number;
+    mimeType?: string;
+    key: string;
+    source: string;
+  }) {
+    const markerKey = this.buildDedupeKey(owner, sha256);
+    const payload = {
+      sha256,
+      sizeBytes: Number(sizeBytes || 0) || undefined,
+      mimeType: mimeType || undefined,
+      canonicalMediaKey: key,
+      createdAt: dayjs.utc().toISOString(),
+      source,
+      owner,
+    };
+
+    try {
+      await this.s3.send(
+        new PutObjectCommand({
+          Bucket: this.bucket,
+          Key: markerKey,
+          ContentType: 'application/json',
+          Body: JSON.stringify(payload),
+        }),
+      );
+    } catch (error) {
+      throw new GeneralError('Failed to write dedupe marker', { error });
+    }
   }
 
   async find(params: Params<MediaQuery>) {
@@ -265,14 +355,84 @@ export class MediaService {
   }
 
   async create(data: UploadInitBody, params: Params) {
-    if (!data || data.action !== 'init-upload') {
-      throw new BadRequest('Unsupported action. Use action="init-upload".');
+    const owner = data.owner || String(params.user?.id || 'anonymous');
+    const normalizedSha = this.normalizeSha256(data.sha256 || undefined);
+
+    if (!data || !data.action) {
+      throw new BadRequest(
+        'Unsupported action. Use action="init-upload", "complete-upload", or "fail-upload".',
+      );
+    }
+
+    if (data.action === 'complete-upload') {
+      if (!data.key) {
+        throw new BadRequest('key is required for complete-upload');
+      }
+      if (!keyContainsOwner(data.key, owner)) {
+        throw new BadRequest('Not allowed to complete this media item');
+      }
+
+      try {
+        await this.s3.send(
+          new HeadObjectCommand({
+            Bucket: this.bucket,
+            Key: data.key,
+          }),
+        );
+      } catch (error) {
+        throw new GeneralError('Uploaded media object not found', { error });
+      }
+
+      if (normalizedSha) {
+        await this.putDedupeMarker({
+          owner,
+          sha256: normalizedSha,
+          sizeBytes: data.sizeBytes,
+          mimeType: data.mimeType,
+          key: data.key,
+          source: 'mobile',
+        });
+      }
+
+      return {
+        key: data.key,
+        completed: true,
+        dedupeIndexed: Boolean(normalizedSha),
+      };
+    }
+
+    if (data.action === 'fail-upload') {
+      return {
+        key: data.key || null,
+        failed: true,
+        reason: data.reason || null,
+      };
+    }
+
+    if (data.action !== 'init-upload') {
+      throw new BadRequest(
+        'Unsupported action. Use action="init-upload", "complete-upload", or "fail-upload".',
+      );
     }
     if (!data.filename) {
       throw new BadRequest('filename is required');
     }
 
-    const owner = data.owner || String(params.user?.id || 'anonymous');
+    if (normalizedSha) {
+      const marker = await this.getDedupeMarker(owner, normalizedSha);
+      if (marker?.canonicalMediaKey) {
+        return {
+          duplicate: true,
+          existingKey: marker.canonicalMediaKey,
+          key: marker.canonicalMediaKey,
+          uploadUrl: null,
+          expiresIn: null,
+          method: null,
+          headers: null,
+        };
+      }
+    }
+
     const key = buildKey({
       capturedAt: data.capturedAt,
       owner,
@@ -298,6 +458,7 @@ export class MediaService {
     );
 
     return {
+      duplicate: false,
       key,
       uploadUrl,
       expiresIn: this.putUrlTtlSeconds,

--- a/src/Days/PostShow/PostPhotos/index.tsx
+++ b/src/Days/PostShow/PostPhotos/index.tsx
@@ -2,12 +2,11 @@ import React, { ReactNode, useContext } from 'react';
 import Button from '@mui/material/Button';
 import { Dialog, Typography, Box } from '@mui/material';
 import Grid from '@mui/material/Grid';
-import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
-import ChevronRightIcon from '@mui/icons-material/ChevronRight';
-import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import GPhotosContext from '../../../shared/context/GPhotosContext';
 import {
+  completeMediaUpload,
   deleteMediaByKey,
+  failMediaUpload,
   getPhotosOnDate,
   initMediaUpload,
   uploadFileToPresignedUrl,
@@ -42,7 +41,10 @@ const PostPhotos = ({
 }: Props) => {
   const [photos, setPhotos] = React.useState<PhotoType[]>([]);
   const [isFetched, setFetched] = React.useState(false);
-  const [previewIndex, setPreviewIndex] = React.useState<number | null>(null);
+  const [previewMedia, setPreviewMedia] = React.useState<{
+    url: string;
+    type: 'image' | 'video';
+  } | null>(null);
   const [isUploading, setUploading] = React.useState(false);
   const [deleteTarget, setDeleteTarget] = React.useState<PhotoType | null>(
     null,
@@ -52,12 +54,6 @@ const PostPhotos = ({
   const {
     value: { token: oauthToken },
   } = useContext(GPhotosContext);
-  const previewMedia =
-    previewIndex !== null && previewIndex >= 0 && previewIndex < photos.length
-      ? photos[previewIndex]
-      : null;
-  const previewType =
-    previewMedia && isVideoMedia(previewMedia) ? 'video' : 'image';
 
   const getPhotos = () => {
     getPhotosOnDate(oauthToken, date)
@@ -77,22 +73,6 @@ const PostPhotos = ({
   const handleUploadButtonClick = () => {
     uploadInputRef.current?.click();
   };
-
-  const showPreviousMedia = React.useCallback(() => {
-    if (!photos.length) return;
-    setPreviewIndex((prev) => {
-      if (prev === null) return 0;
-      return (prev - 1 + photos.length) % photos.length;
-    });
-  }, [photos.length]);
-
-  const showNextMedia = React.useCallback(() => {
-    if (!photos.length) return;
-    setPreviewIndex((prev) => {
-      if (prev === null) return 0;
-      return (prev + 1) % photos.length;
-    });
-  }, [photos.length]);
 
   const confirmDeletePhoto = async () => {
     if (!deleteTarget?.id) return;
@@ -124,35 +104,56 @@ const PostPhotos = ({
       const capturedAt = Number.isNaN(parsedDate.getTime())
         ? new Date().toISOString()
         : parsedDate.toISOString();
-      const uploadTasks = Array.from(files).map(async (file) => {
+      for (const file of Array.from(files)) {
+        let uploadKey: string | null = null;
         const { data, error } = await initMediaUpload({
           filename: file.name,
           mimeType: file.type,
           capturedAt,
         });
-        if (error || !data?.uploadUrl) {
+        if (error || !data) {
           throw error || new Error('Upload init failed');
         }
+
+        if (data.duplicate) {
+          continue;
+        }
+
+        uploadKey = data.key;
+        if (!data.uploadUrl) {
+          throw new Error('Upload URL is missing');
+        }
+
         const uploadResult = await uploadFileToPresignedUrl({
           uploadUrl: data.uploadUrl,
           file,
           mimeType: file.type,
         });
         if (uploadResult.error) {
+          await failMediaUpload({
+            key: uploadKey,
+            reason:
+              uploadResult.error?.message ||
+              'Presigned upload failed on client',
+          });
           throw uploadResult.error;
         }
-      });
-      const results = await Promise.allSettled(uploadTasks);
-      const hasSuccess = results.some(
-        (result) => result.status === 'fulfilled',
-      );
-      const hasFailure = results.some((result) => result.status === 'rejected');
-      if (hasSuccess) {
-        getPhotos();
+
+        const completeResult = await completeMediaUpload({
+          key: uploadKey,
+          mimeType: file.type,
+          capturedAt,
+          sizeBytes: file.size,
+        });
+        if (completeResult.error) {
+          await failMediaUpload({
+            key: uploadKey,
+            reason: completeResult.error?.message || 'Complete upload failed',
+          });
+          throw completeResult.error;
+        }
       }
-      if (hasFailure) {
-        throw new Error('Some files failed to upload');
-      }
+      getPhotos();
     } catch (error) {
       console.log(error);
     } finally {
@@ -160,24 +161,6 @@ const PostPhotos = ({
       setUploading(false);
     }
   };
-
-  React.useEffect(() => {
-    if (previewIndex === null) {
-      return;
-    }
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'ArrowLeft') {
-        event.preventDefault();
-        showPreviousMedia();
-      }
-      if (event.key === 'ArrowRight') {
-        event.preventDefault();
-        showNextMedia();
-      }
-    };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [previewIndex, showNextMedia, showPreviousMedia]);
 
   return (
     <Grid
@@ -201,7 +184,7 @@ const PostPhotos = ({
           <Button onClick={getPhotos}>GET PHOTOS</Button>
         ) : null}
         <Button onClick={handleUploadButtonClick} disabled={isUploading}>
-          {isUploading ? 'UPLOADING...' : 'UPLOAD FILES'}
+          {isUploading ? 'UPLOADING...' : 'UPLOAD PHOTO'}
         </Button>
       </Grid>
       {isFetched && !photos.length ? (
@@ -209,7 +192,7 @@ const PostPhotos = ({
       ) : null}
       {isFetched && photos.length ? (
         <Grid container spacing={1}>
-          {photos.map((p, index) => (
+          {photos.map((p) => (
             <Grid key={p.id}>
               <Grid container direction="column" spacing={0.5}>
                 <Grid>
@@ -221,30 +204,14 @@ const PostPhotos = ({
                       height: 70,
                       cursor: 'pointer',
                       backgroundImage: `url(${p.baseUrl})`,
-                      position: 'relative',
-                      borderRadius: 0.5,
-                      overflow: 'hidden',
                     }}
-                    onClick={() => setPreviewIndex(index)}
-                  >
-                    {isVideoMedia(p) ? (
-                      <Box
-                        sx={{
-                          position: 'absolute',
-                          inset: 0,
-                          display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          backgroundColor: 'rgba(0, 0, 0, 0.35)',
-                        }}
-                      >
-                        <PlayArrowIcon
-                          sx={{ color: '#fff', fontSize: 32 }}
-                          aria-label="video"
-                        />
-                      </Box>
-                    ) : null}
-                  </Box>
+                    onClick={() =>
+                      setPreviewMedia({
+                        url: p.baseUrl,
+                        type: isVideoMedia(p) ? 'video' : 'image',
+                      })
+                    }
+                  />
                 </Grid>
                 <Grid>
                   <Button
@@ -261,94 +228,27 @@ const PostPhotos = ({
           ))}
         </Grid>
       ) : null}
-      <Dialog
-        open={previewIndex !== null}
-        onClose={() => setPreviewIndex(null)}
-        fullScreen
-        PaperProps={{
-          sx: {
-            backgroundColor: 'rgba(0, 0, 0, 0.85)',
-          },
-        }}
-      >
-        <Box
-          sx={{
-            position: 'relative',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            width: '100vw',
-            height: '100vh',
-          }}
-        >
-          {photos.length > 1 ? (
-            <Button
-              onClick={showPreviousMedia}
-              sx={{
-                position: 'fixed',
-                left: 0,
-                top: 0,
-                bottom: 0,
-                borderRadius: 0,
-                width: { xs: 56, sm: 80 },
-                minWidth: 0,
-                color: '#fff',
-                zIndex: 1,
-                '&:hover': {
-                  backgroundColor: 'rgba(255, 255, 255, 0.08)',
-                },
-              }}
-              aria-label="Previous file"
-            >
-              <ChevronLeftIcon sx={{ fontSize: 40 }} />
-            </Button>
-          ) : null}
-          {previewMedia ? (
-            previewType === 'video' ? (
-              <video
-                src={previewMedia.baseUrl}
-                controls
-                autoPlay
-                style={{
-                  maxWidth: 'calc(100vw - 160px)',
-                  maxHeight: '95vh',
-                }}
-              />
-            ) : (
-              <img
-                src={previewMedia.baseUrl}
-                style={{
-                  maxWidth: 'calc(100vw - 160px)',
-                  maxHeight: '95vh',
-                  objectFit: 'contain',
-                }}
-                alt={date.toString()}
-              />
-            )
-          ) : null}
-          {photos.length > 1 ? (
-            <Button
-              onClick={showNextMedia}
-              sx={{
-                position: 'fixed',
-                right: 0,
-                top: 0,
-                bottom: 0,
-                borderRadius: 0,
-                width: { xs: 56, sm: 80 },
-                minWidth: 0,
-                color: '#fff',
-                zIndex: 1,
-                '&:hover': {
-                  backgroundColor: 'rgba(255, 255, 255, 0.08)',
-                },
-              }}
-              aria-label="Next file"
-            >
-              <ChevronRightIcon sx={{ fontSize: 40 }} />
-            </Button>
-          ) : null}
-        </Box>
+      <Dialog open={!!previewMedia} onClose={() => setPreviewMedia(null)}>
+        {previewMedia?.type === 'video' ? (
+          <video
+            src={previewMedia.url}
+            controls
+            autoPlay
+            style={{
+              maxWidth: '90vw',
+              maxHeight: '90vh',
+            }}
+          />
+        ) : (
+          <img
+            src={previewMedia?.url}
+            style={{
+              maxWidth: '90vw',
+              maxHeight: '90vh',
+            }}
+            alt={date.toString()}
+          />
+        )}
       </Dialog>
       <Dialog open={!!deleteTarget} onClose={() => setDeleteTarget(null)}>
         <Box sx={{ padding: 2, maxWidth: 360 }}>

--- a/src/shared/utils/photos.js
+++ b/src/shared/utils/photos.js
@@ -111,6 +111,73 @@ export const initMediaUpload = async ({ filename, mimeType, capturedAt }) => {
   return { data, error };
 };
 
+export const completeMediaUpload = async ({
+  key,
+  mimeType,
+  capturedAt,
+  sizeBytes,
+}) => {
+  let data = null;
+  let error = null;
+
+  try {
+    const response = await fetch(`${LOCAL}/media`, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({
+        action: 'complete-upload',
+        key,
+        mimeType,
+        capturedAt,
+        sizeBytes,
+      }),
+    });
+    const result = await response.json();
+    if (response.ok && !result.error) {
+      data = result;
+    } else {
+      error = result.error || {
+        code: response.status,
+        message: 'Failed to complete upload',
+      };
+    }
+  } catch (err) {
+    error = err;
+  }
+
+  return { data, error };
+};
+
+export const failMediaUpload = async ({ key, reason }) => {
+  let data = null;
+  let error = null;
+
+  try {
+    const response = await fetch(`${LOCAL}/media`, {
+      method: 'POST',
+      headers: authHeaders(),
+      body: JSON.stringify({
+        action: 'fail-upload',
+        key,
+        reason,
+      }),
+    });
+    const result = await response.json();
+    if (response.ok && !result.error) {
+      data = result;
+    } else {
+      error = result.error || {
+        code: response.status,
+        message: 'Failed to report upload failure',
+      };
+    }
+  } catch (err) {
+    error = err;
+  }
+
+  return { data, error };
+};
+
 export const uploadFileToPresignedUrl = async ({
   uploadUrl,
   file,


### PR DESCRIPTION
## What changed
- Replaced day-based Google Photos dependency with an S3-backed media flow in backend and frontend.
- Added robust Google Takeout migration tooling:
  - `scripts/upload-takeout-to-s3.js` and `scripts/upload-takeout-folder-to-s3.js`
  - resumable state tracking, deferred/failed logging, pair upload handling for media + metadata sidecars
  - improved metadata matching for split Takeout roots (`Takeout`, `Takeout 2`, etc.), copy-suffix variants, truncated supplemental JSON names, and Unicode-safe paths
  - retry handling for S3 clock skew and configurable concurrency for faster migration
  - fallback timestamp extraction from filename and optional EXIF-based fallback support
- Updated media key strategy and retrieval behavior for diary day views:
  - date-partitioned keys (`date=YYYY-MM-DD`)
  - day-based querying fixes to avoid timezone drift in FE requests
  - media-only filtering in listing responses
- Added FE/BE media management improvements:
  - upload button in post view
  - delete media API + FE confirmation dialog
  - video playback in preview dialog
  - button/layout refinements in post actions
- Added architecture and implementation groundwork for mobile auto-upload:
  - plan doc for Android background sync and S3 hash dedupe index
  - backend dedupe lifecycle support via media actions: `init-upload`, `complete-upload`, `fail-upload`
  - S3 hash-index backfill script: `scripts/backfill-s3-hash-index.js`
  - FE upload flow aligned to the same lifecycle contract used by the planned mobile app

## Why
- Google Photos API dependency is no longer viable for this diary workflow.
- The diary needs reliable, low-touch day-based media retrieval from owned storage with minimal operational overhead.
- Historical Takeout imports needed to be safe and resumable across large/split archives while preserving metadata where possible.
- Future Android auto-upload requires duplicate-aware semantics without introducing a database.

## Important implementation details
- Existing migrated objects keep timestamp/date-based keys; no key rewrite required for backward compatibility with current diary rendering.
- Duplicate detection is introduced via S3 hash index markers (SHA-256), not by changing primary media keys.
- Upload lifecycle now supports idempotent app-style flow:
  1. `init-upload` (can return duplicate hit)
  2. upload to presigned URL
  3. `complete-upload` to finalize/index
  4. `fail-upload` for explicit failure reporting
- Takeout import scripts are designed for incremental execution and cleanup under low disk space constraints.

This PR was written using [Vibe Kanban](https://vibekanban.com)
