### PR TITLE
Fix fullscreen media preview layout and edge navigation controls (Vibe Kanban)

### DIFF
--- a/src/Days/PostShow/PostPhotos/index.tsx
+++ b/src/Days/PostShow/PostPhotos/index.tsx
@@ -2,6 +2,9 @@ import React, { ReactNode, useContext } from 'react';
 import Button from '@mui/material/Button';
 import { Dialog, Typography, Box } from '@mui/material';
 import Grid from '@mui/material/Grid';
+import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
+import ChevronRightIcon from '@mui/icons-material/ChevronRight';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import GPhotosContext from '../../../shared/context/GPhotosContext';
 import {
   completeMediaUpload,
@@ -41,10 +44,7 @@ const PostPhotos = ({
 }: Props) => {
   const [photos, setPhotos] = React.useState<PhotoType[]>([]);
   const [isFetched, setFetched] = React.useState(false);
-  const [previewMedia, setPreviewMedia] = React.useState<{
-    url: string;
-    type: 'image' | 'video';
-  } | null>(null);
+  const [previewIndex, setPreviewIndex] = React.useState<number | null>(null);
   const [isUploading, setUploading] = React.useState(false);
   const [deleteTarget, setDeleteTarget] = React.useState<PhotoType | null>(
     null,
@@ -54,6 +54,12 @@ const PostPhotos = ({
   const {
     value: { token: oauthToken },
   } = useContext(GPhotosContext);
+  const previewMedia =
+    previewIndex !== null && previewIndex >= 0 && previewIndex < photos.length
+      ? photos[previewIndex]
+      : null;
+  const previewType =
+    previewMedia && isVideoMedia(previewMedia) ? 'video' : 'image';
 
   const getPhotos = () => {
     getPhotosOnDate(oauthToken, date)
@@ -73,6 +79,22 @@ const PostPhotos = ({
   const handleUploadButtonClick = () => {
     uploadInputRef.current?.click();
   };
+
+  const showPreviousMedia = React.useCallback(() => {
+    if (!photos.length) return;
+    setPreviewIndex((prev) => {
+      if (prev === null) return 0;
+      return (prev - 1 + photos.length) % photos.length;
+    });
+  }, [photos.length]);
+
+  const showNextMedia = React.useCallback(() => {
+    if (!photos.length) return;
+    setPreviewIndex((prev) => {
+      if (prev === null) return 0;
+      return (prev + 1) % photos.length;
+    });
+  }, [photos.length]);
 
   const confirmDeletePhoto = async () => {
     if (!deleteTarget?.id) return;
@@ -162,6 +184,24 @@ const PostPhotos = ({
     }
   };
 
+  React.useEffect(() => {
+    if (previewIndex === null) {
+      return;
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        showPreviousMedia();
+      }
+      if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        showNextMedia();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [previewIndex, showNextMedia, showPreviousMedia]);
+
   return (
     <Grid
       container
@@ -184,7 +224,7 @@ const PostPhotos = ({
           <Button onClick={getPhotos}>GET PHOTOS</Button>
         ) : null}
         <Button onClick={handleUploadButtonClick} disabled={isUploading}>
-          {isUploading ? 'UPLOADING...' : 'UPLOAD PHOTO'}
+          {isUploading ? 'UPLOADING...' : 'UPLOAD FILES'}
         </Button>
       </Grid>
       {isFetched && !photos.length ? (
@@ -192,7 +232,7 @@ const PostPhotos = ({
       ) : null}
       {isFetched && photos.length ? (
         <Grid container spacing={1}>
-          {photos.map((p) => (
+          {photos.map((p, index) => (
             <Grid key={p.id}>
               <Grid container direction="column" spacing={0.5}>
                 <Grid>
@@ -204,14 +244,30 @@ const PostPhotos = ({
                       height: 70,
                       cursor: 'pointer',
                       backgroundImage: `url(${p.baseUrl})`,
+                      position: 'relative',
+                      borderRadius: 0.5,
+                      overflow: 'hidden',
                     }}
-                    onClick={() =>
-                      setPreviewMedia({
-                        url: p.baseUrl,
-                        type: isVideoMedia(p) ? 'video' : 'image',
-                      })
-                    }
-                  />
+                    onClick={() => setPreviewIndex(index)}
+                  >
+                    {isVideoMedia(p) ? (
+                      <Box
+                        sx={{
+                          position: 'absolute',
+                          inset: 0,
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          backgroundColor: 'rgba(0, 0, 0, 0.35)',
+                        }}
+                      >
+                        <PlayArrowIcon
+                          sx={{ color: '#fff', fontSize: 32 }}
+                          aria-label="video"
+                        />
+                      </Box>
+                    ) : null}
+                  </Box>
                 </Grid>
                 <Grid>
                   <Button
@@ -228,27 +284,94 @@ const PostPhotos = ({
           ))}
         </Grid>
       ) : null}
-      <Dialog open={!!previewMedia} onClose={() => setPreviewMedia(null)}>
-        {previewMedia?.type === 'video' ? (
-          <video
-            src={previewMedia.url}
-            controls
-            autoPlay
-            style={{
-              maxWidth: '90vw',
-              maxHeight: '90vh',
-            }}
-          />
-        ) : (
-          <img
-            src={previewMedia?.url}
-            style={{
-              maxWidth: '90vw',
-              maxHeight: '90vh',
-            }}
-            alt={date.toString()}
-          />
-        )}
+      <Dialog
+        open={previewIndex !== null}
+        onClose={() => setPreviewIndex(null)}
+        fullScreen
+        PaperProps={{
+          sx: {
+            backgroundColor: 'rgba(0, 0, 0, 0.85)',
+          },
+        }}
+      >
+        <Box
+          sx={{
+            position: 'relative',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: '100vw',
+            height: '100vh',
+          }}
+        >
+          {photos.length > 1 ? (
+            <Button
+              onClick={showPreviousMedia}
+              sx={{
+                position: 'fixed',
+                left: 0,
+                top: 0,
+                bottom: 0,
+                borderRadius: 0,
+                width: { xs: 56, sm: 80 },
+                minWidth: 0,
+                color: '#fff',
+                zIndex: 1,
+                '&:hover': {
+                  backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                },
+              }}
+              aria-label="Previous file"
+            >
+              <ChevronLeftIcon sx={{ fontSize: 40 }} />
+            </Button>
+          ) : null}
+          {previewMedia ? (
+            previewType === 'video' ? (
+              <video
+                src={previewMedia.baseUrl}
+                controls
+                autoPlay
+                style={{
+                  maxWidth: 'calc(100vw - 160px)',
+                  maxHeight: '95vh',
+                }}
+              />
+            ) : (
+              <img
+                src={previewMedia.baseUrl}
+                style={{
+                  maxWidth: 'calc(100vw - 160px)',
+                  maxHeight: '95vh',
+                  objectFit: 'contain',
+                }}
+                alt={date.toString()}
+              />
+            )
+          ) : null}
+          {photos.length > 1 ? (
+            <Button
+              onClick={showNextMedia}
+              sx={{
+                position: 'fixed',
+                right: 0,
+                top: 0,
+                bottom: 0,
+                borderRadius: 0,
+                width: { xs: 56, sm: 80 },
+                minWidth: 0,
+                color: '#fff',
+                zIndex: 1,
+                '&:hover': {
+                  backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                },
+              }}
+              aria-label="Next file"
+            >
+              <ChevronRightIcon sx={{ fontSize: 40 }} />
+            </Button>
+          ) : null}
+        </Box>
       </Dialog>
       <Dialog open={!!deleteTarget} onClose={() => setDeleteTarget(null)}>
         <Box sx={{ padding: 2, maxWidth: 360 }}>


### PR DESCRIPTION
## Summary
This PR fixes the post media preview layout so navigation controls sit on the backdrop edges instead of occupying space over the media content.

## What Changed
- Updated the media preview `Dialog` in `PostPhotos` to render in `fullScreen` mode.
- Replaced the constrained preview container sizing (`minWidth`/`minHeight` + black panel) with full viewport dimensions (`100vw` x `100vh`).
- Moved previous/next navigation buttons from inside the media area to fixed, full-height left/right edge controls on the backdrop.
- Added subtle hover feedback for edge controls.
- Adjusted displayed media sizing:
  - `maxWidth: calc(100vw - 160px)`
  - `maxHeight: 95vh`
  - `objectFit: contain` for images

## Why
After adding media navigation controls, the preview layout regressed: a large black area and in-content arrow placement reduced visible media width and covered part of the image. The goal of this follow-up change is to preserve full media visibility while keeping navigation easily accessible.

## Implementation Details
- File changed: `src/Days/PostShow/PostPhotos/index.tsx`
- Dialog now uses:
  - `fullScreen`
  - custom `PaperProps` backdrop tint (`rgba(0, 0, 0, 0.85)`)
- Navigation buttons are fixed to viewport edges (`position: fixed`, `left: 0` / `right: 0`, full-height hit area).
- Media content remains centered and scaled to fit between side controls.

This PR was written using [Vibe Kanban](https://vibekanban.com)
