### PR TITLE
Add S3 hash-dedupe upload lifecycle and migration backfill tooling (Vibe Kanban)

### DIFF
--- a/src/Days/PostShow/PostPhotos/index.tsx
+++ b/src/Days/PostShow/PostPhotos/index.tsx
@@ -8,6 +8,7 @@ import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import GPhotosContext from '../../../shared/context/GPhotosContext';
 import {
   completeMediaUpload,
+  computeFileSha256,
   deleteMediaByKey,
   failMediaUpload,
   getPhotosOnDate,
@@ -128,10 +129,13 @@ const PostPhotos = ({
         : parsedDate.toISOString();
       for (const file of Array.from(files)) {
         let uploadKey: string | null = null;
+        const sha256 = await computeFileSha256(file);
         const { data, error } = await initMediaUpload({
           filename: file.name,
           mimeType: file.type,
           capturedAt,
+          sizeBytes: file.size,
+          sha256,
         });
         if (error || !data) {
           throw error || new Error('Upload init failed');
@@ -166,6 +170,7 @@ const PostPhotos = ({
           mimeType: file.type,
           capturedAt,
           sizeBytes: file.size,
+          sha256,
         });
         if (completeResult.error) {
           await failMediaUpload({

--- a/src/shared/utils/photos.js
+++ b/src/shared/utils/photos.js
@@ -80,7 +80,25 @@ export const getPhotosOnDate = async (
   return { photos, error };
 };
 
-export const initMediaUpload = async ({ filename, mimeType, capturedAt }) => {
+const toHex = (buffer) =>
+  Array.from(new Uint8Array(buffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+
+export const computeFileSha256 = async (file) => {
+  if (!file) return null;
+  const arrayBuffer = await file.arrayBuffer();
+  const digest = await crypto.subtle.digest('SHA-256', arrayBuffer);
+  return toHex(digest);
+};
+
+export const initMediaUpload = async ({
+  filename,
+  mimeType,
+  capturedAt,
+  sizeBytes,
+  sha256,
+}) => {
   let data = null;
   let error = null;
 
@@ -93,6 +111,8 @@ export const initMediaUpload = async ({ filename, mimeType, capturedAt }) => {
         filename,
         mimeType,
         capturedAt,
+        sizeBytes,
+        sha256,
       }),
     });
     const result = await response.json();
@@ -116,6 +136,7 @@ export const completeMediaUpload = async ({
   mimeType,
   capturedAt,
   sizeBytes,
+  sha256,
 }) => {
   let data = null;
   let error = null;
@@ -130,6 +151,7 @@ export const completeMediaUpload = async ({
         mimeType,
         capturedAt,
         sizeBytes,
+        sha256,
       }),
     });
     const result = await response.json();


### PR DESCRIPTION
## What changes were made
- Added an end-to-end S3 media evolution focused on duplicate-aware uploads without introducing a DB.
- Added a dedicated architecture plan document for Android auto-upload + S3 hash dedupe:
  - `docs/mobile-auto-upload-dedupe-plan.md`
- Added a backfill utility to index already-migrated media by content hash:
  - `scripts/backfill-s3-hash-index.js`
- Extended backend media service to support dedupe lifecycle actions and S3 index markers:
  - `init-upload` now supports hash-aware duplicate lookup
  - `complete-upload` persists dedupe marker metadata
  - `fail-upload` records explicit upload failure intent
  - S3 dedupe index keying helpers and marker read/write flow were added in `server/services/media/media.class.ts`
- Updated frontend upload flow to use the same lifecycle contract as the upcoming mobile app:
  - FE now computes SHA-256 for selected files
  - FE sends hash/size to `init-upload`
  - FE completes with `complete-upload` after successful PUT
  - FE reports failed uploads with `fail-upload`
  - implemented in `src/shared/utils/photos.js` and `src/Days/PostShow/PostPhotos/index.tsx`

## Why these changes were made
- The project is moving off Google Photos to owned S3 storage.
- Next step is Android auto-upload behavior similar to Google Photos, which requires reliable dedupe semantics.
- Existing migrated media must be recognized as already uploaded, so backfilling a hash index is needed.
- FE and mobile clients should share one upload API lifecycle to keep behavior consistent and reduce integration drift.

## Important implementation details
- Existing media object keys remain timestamp/date-based (no mass key rewrite required).
- Duplicate detection is handled via S3 hash index markers rather than a relational DB.
- Hash dedupe behavior depends on clients sending SHA-256; FE now does this.
- Backfill script is designed to build dedupe markers for historical migrated content so future uploads can be skipped when identical media already exists.

This PR was written using [Vibe Kanban](https://vibekanban.com)
