### PR TITLE
Add explicit close control to fullscreen media preview (Vibe Kanban)

### DIFF
--- a/src/Days/PostShow/PostPhotos/index.tsx
+++ b/src/Days/PostShow/PostPhotos/index.tsx
@@ -1,10 +1,11 @@
 import React, { ReactNode, useContext } from 'react';
 import Button from '@mui/material/Button';
-import { Dialog, Typography, Box } from '@mui/material';
+import { Dialog, Typography, Box, IconButton } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import CloseIcon from '@mui/icons-material/Close';
 import GPhotosContext from '../../../shared/context/GPhotosContext';
 import {
   completeMediaUpload,
@@ -309,6 +310,23 @@ const PostPhotos = ({
             height: '100vh',
           }}
         >
+          <IconButton
+            onClick={() => setPreviewIndex(null)}
+            aria-label="Close preview"
+            sx={{
+              position: 'fixed',
+              top: 12,
+              right: 12,
+              color: '#fff',
+              zIndex: 2,
+              backgroundColor: 'rgba(0, 0, 0, 0.35)',
+              '&:hover': {
+                backgroundColor: 'rgba(0, 0, 0, 0.55)',
+              },
+            }}
+          >
+            <CloseIcon />
+          </IconButton>
           {photos.length > 1 ? (
             <Button
               onClick={showPreviousMedia}


### PR DESCRIPTION
## Summary
Adds a dedicated close button to the fullscreen media preview in the post photos view.

## What Changed
- Updated `src/Days/PostShow/PostPhotos/index.tsx`.
- Added `IconButton` and `CloseIcon` imports from MUI.
- Rendered a fixed top-right close button inside the fullscreen `Dialog`.
- Wired the button to `setPreviewIndex(null)` so it exits fullscreen preview immediately.
- Kept existing navigation and dialog behavior intact (left/right navigation buttons, backdrop/`onClose` handling).

## Why
The task context identified a usability gap: when viewing photos in fullscreen, there was no obvious in-UI way to close the preview. This change adds an explicit, always-visible control so users can reliably exit fullscreen mode, especially on touch devices where keyboard-based dismissal is less discoverable.

## Implementation Details
- The new close control uses a high z-index and semi-transparent dark background to stay visible over both light and dark media.
- Positioning is fixed to the top-right corner for consistent access regardless of image/video size.
- The close action reuses existing preview state logic (`previewIndex`) rather than introducing new dialog state.

This PR was written using [Vibe Kanban](https://vibekanban.com)
