### PR TITLE
Add post photo pagination and fix nextPageToken behavior (Vibe Kanban)

### DIFF
--- a/server/services/media/media.class.ts
+++ b/server/services/media/media.class.ts
@@ -280,7 +280,9 @@ export class MediaService {
           Bucket: this.bucket,
           Prefix: prefix,
           ContinuationToken: continuationToken,
-          MaxKeys: 1000,
+          // Keep S3 page size aligned with API page size so NextContinuationToken
+          // correctly represents "there is more data for this query page".
+          MaxKeys: pageSize,
         }),
       );
       continuationToken = result.NextContinuationToken;

--- a/src/Days/PostShow/PostPhotos/index.tsx
+++ b/src/Days/PostShow/PostPhotos/index.tsx
@@ -46,6 +46,8 @@ const PostPhotos = ({
 }: Props) => {
   const [photos, setPhotos] = React.useState<PhotoType[]>([]);
   const [isFetched, setFetched] = React.useState(false);
+  const [nextPageToken, setNextPageToken] = React.useState<string | null>(null);
+  const [isLoadingMore, setLoadingMore] = React.useState(false);
   const [previewIndex, setPreviewIndex] = React.useState<number | null>(null);
   const [isUploading, setUploading] = React.useState(false);
   const [deleteTarget, setDeleteTarget] = React.useState<PhotoType | null>(
@@ -64,18 +66,57 @@ const PostPhotos = ({
     previewMedia && isVideoMedia(previewMedia) ? 'video' : 'image';
 
   const getPhotos = () => {
-    getPhotosOnDate(oauthToken, date)
+    getPhotosOnDate(oauthToken, date, undefined, undefined, 100)
       .then(({ photos, error }) => {
         setFetched(true);
         if (error) {
           console.log(error);
+          setNextPageToken(null);
           return;
         }
         if (photos?.mediaItems) {
           setPhotos(photos.mediaItems);
+          setNextPageToken(photos?.nextPageToken || null);
+          return;
         }
+        setPhotos([]);
+        setNextPageToken(null);
       })
       .catch(console.log);
+  };
+
+  const loadMorePhotos = async () => {
+    if (!nextPageToken || isLoadingMore) {
+      return;
+    }
+    setLoadingMore(true);
+    try {
+      const { photos: nextPhotos, error } = await getPhotosOnDate(
+        oauthToken,
+        date,
+        undefined,
+        nextPageToken,
+        100,
+      );
+      if (error) {
+        console.log(error);
+        return;
+      }
+      if (nextPhotos?.mediaItems?.length) {
+        setPhotos((prev) => {
+          const existingIds = new Set(prev.map((item) => item.id));
+          const uniqueNewItems = nextPhotos.mediaItems.filter(
+            (item: PhotoType) => !existingIds.has(item.id),
+          );
+          return [...prev, ...uniqueNewItems];
+        });
+      }
+      setNextPageToken(nextPhotos?.nextPageToken || null);
+    } catch (error) {
+      console.log(error);
+    } finally {
+      setLoadingMore(false);
+    }
   };
 
   const handleUploadButtonClick = () => {
@@ -228,6 +269,11 @@ const PostPhotos = ({
         {extraAction ? <Box>{extraAction}</Box> : null}
         {!isFetched && !hideGetPhotosButton ? (
           <Button onClick={getPhotos}>GET PHOTOS</Button>
+        ) : null}
+        {isFetched && nextPageToken ? (
+          <Button onClick={loadMorePhotos} disabled={isLoadingMore}>
+            {isLoadingMore ? 'LOADING...' : 'LOAD MORE'}
+          </Button>
         ) : null}
         <Button onClick={handleUploadButtonClick} disabled={isUploading}>
           {isUploading ? 'UPLOADING...' : 'UPLOAD FILES'}

--- a/src/shared/utils/photos.js
+++ b/src/shared/utils/photos.js
@@ -39,13 +39,14 @@ export const getPhotosOnDate = async (
   date,
   ranges,
   nextPageToken,
+  pageSize = 100,
 ) => {
   let photos = [];
   let error = null;
 
   try {
     const params = new URLSearchParams();
-    params.set('pageSize', '24');
+    params.set('pageSize', String(pageSize));
     if (nextPageToken) {
       params.set('pageToken', nextPageToken);
     }


### PR DESCRIPTION
## What changed
- Implemented post-level media pagination in the diary UI (`PostPhotos`):
  - Initial `GET PHOTOS` request now uses `pageSize=100`.
  - Added `nextPageToken` state handling.
  - Added a `LOAD MORE` button that appears only when more results are available.
  - Appends subsequent pages instead of replacing existing items.
  - Added client-side id de-duplication when appending pages.
- Updated shared media fetch utility (`getPhotosOnDate`) to accept a configurable `pageSize` argument, defaulting to `100`.
- Fixed backend pagination token behavior in `MediaService`:
  - Changed S3 `ListObjectsV2` `MaxKeys` from a fixed `1000` to the requested API `pageSize`.
  - This ensures `nextPageToken` correctly indicates whether more results exist for the current query page.

## Why
The previous behavior had a hard effective limit and unreliable pagination flow for post photos:
- FE initially requested too small a page by default.
- Backend used a much larger S3 page size than API page size, which could consume all matching keys in one S3 call and return `nextPageToken: null` even when the UI still needed pagination semantics.

This PR makes post photo retrieval predictable and scalable for large day buckets, while keeping the UX simple with a single explicit “load more” action.

## Implementation details
- FE calls now pass `pageSize=100` explicitly for post photos.
- Pagination UI is state-driven (`isFetched`, `nextPageToken`, `isLoadingMore`).
- `LOAD MORE` is hidden when no continuation token is returned.
- Backend token propagation now aligns S3 listing size with requested API page size, so continuation tokens map cleanly to UI pagination.

This PR was written using [Vibe Kanban](https://vibekanban.com)
