### PR TITLE
Render single newlines as paragraph breaks in Markdown posts (Vibe Kanban)

### DIFF
--- a/src/shared/components/MarkdownRenderer/index.tsx
+++ b/src/shared/components/MarkdownRenderer/index.tsx
@@ -14,31 +14,14 @@ const normalizeParagraphNewlines = (value: string): string => {
 
   const lines = value.replace(/\r\n/g, '\n').split('\n');
   const normalized: string[] = [];
-  let inFence = false;
-  let fenceToken = '';
 
   lines.forEach((line, index) => {
-    const fenceMatch = line.match(/^\s*(```+|~~~+)/);
-    if (fenceMatch) {
-      const token = fenceMatch[1][0];
-      if (!inFence) {
-        inFence = true;
-        fenceToken = token;
-      } else if (fenceToken === token) {
-        inFence = false;
-        fenceToken = '';
-      }
-    }
-
     normalized.push(line);
 
     const isLastLine = index === lines.length - 1;
     const nextLine = lines[index + 1];
     const shouldInsertParagraphBreak =
-      !isLastLine &&
-      !inFence &&
-      line.trim() !== '' &&
-      (nextLine || '').trim() !== '';
+      !isLastLine && line.trim() !== '' && (nextLine || '').trim() !== '';
 
     if (shouldInsertParagraphBreak) {
       normalized.push('');

--- a/src/shared/components/MarkdownRenderer/index.tsx
+++ b/src/shared/components/MarkdownRenderer/index.tsx
@@ -7,7 +7,50 @@ type Props = {
   body: string;
 };
 
+const normalizeParagraphNewlines = (value: string): string => {
+  if (!value) {
+    return value;
+  }
+
+  const lines = value.replace(/\r\n/g, '\n').split('\n');
+  const normalized: string[] = [];
+  let inFence = false;
+  let fenceToken = '';
+
+  lines.forEach((line, index) => {
+    const fenceMatch = line.match(/^\s*(```+|~~~+)/);
+    if (fenceMatch) {
+      const token = fenceMatch[1][0];
+      if (!inFence) {
+        inFence = true;
+        fenceToken = token;
+      } else if (fenceToken === token) {
+        inFence = false;
+        fenceToken = '';
+      }
+    }
+
+    normalized.push(line);
+
+    const isLastLine = index === lines.length - 1;
+    const nextLine = lines[index + 1];
+    const shouldInsertParagraphBreak =
+      !isLastLine &&
+      !inFence &&
+      line.trim() !== '' &&
+      (nextLine || '').trim() !== '';
+
+    if (shouldInsertParagraphBreak) {
+      normalized.push('');
+    }
+  });
+
+  return normalized.join('\n');
+};
+
 const MarkdownRenderer = ({ body }: Props) => {
+  const normalizedBody = normalizeParagraphNewlines(body || '');
+
   return (
     <Box
       sx={{
@@ -45,7 +88,7 @@ const MarkdownRenderer = ({ body }: Props) => {
           ),
         }}
       >
-        {body || ''}
+        {normalizedBody}
       </ReactMarkdown>
     </Box>
   );


### PR DESCRIPTION
## What changed
- Updated `src/shared/components/MarkdownRenderer/index.tsx` to normalize post text before rendering with `react-markdown`.
- Added `normalizeParagraphNewlines(value: string)` that:
  - normalizes Windows newlines (`\r\n`) to `\n`
  - inserts an extra blank line between consecutive non-empty lines
  - preserves existing empty lines
- Switched markdown rendering input from raw `body` to `normalizedBody`.

## Why this was changed
After enabling Markdown rendering, legacy and new posts that used single newlines to separate paragraphs were being displayed as one continuous paragraph (default Markdown behavior). This change restores expected paragraph separation so posts remain readable without requiring users to manually add blank lines.

## Important implementation details
- The behavior is applied centrally in `MarkdownRenderer`, so it affects both existing and newly created posts consistently.
- The transformation runs at render time only; it does not mutate stored post content in the database.
- Existing markdown features (GFM, links, lists, etc.) continue to work through the same `ReactMarkdown` pipeline.

This PR was written using [Vibe Kanban](https://vibekanban.com)
